### PR TITLE
fix: slack join link

### DIFF
--- a/community/05-contact.md
+++ b/community/05-contact.md
@@ -11,7 +11,7 @@ If you are interested in our EventMesh project, please feel free to contact us!
 
 | WeChat Assistant                                              | WeChat Official Account                                      | Slack                                                                                                         |
 |---------------------------------------------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| <img src="/images/contact/wechat-assistant.jpg" width="128"/> | <img src="/images/contact/wechat-official.jpg" width="128"/> | [Join Slack Chat](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1blhcbedu-9b7yvwAQcDs3fddZxnZXag) |
+| <img src="/images/contact/wechat-assistant.jpg" width="128"/> | <img src="/images/contact/wechat-official.jpg" width="128"/> | [Join Slack Chat](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1vpgrvm5u-hh~5H9Aj4TGThaP9tusFfw) |
 
 ## Mailing List
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -8,7 +8,7 @@ sidebar_position: 0
 [![CodeCov](https://img.shields.io/codecov/c/gh/apache/incubator-eventmesh/master?logo=codecov&style=for-the-badge)](https://codecov.io/gh/apache/incubator-eventmesh)
 [![License](https://img.shields.io/github/license/apache/incubator-eventmesh?style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![GitHub Release](https://img.shields.io/github/v/release/apache/eventmesh?style=for-the-badge)](https://github.com/apache/incubator-eventmesh/releases)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-blue.svg?logo=slack&style=for-the-badge)](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-16y1n77va-q~JepYy3RqpkygDYmQaQbw)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-blue.svg?logo=slack&style=for-the-badge)](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1vpgrvm5u-hh~5H9Aj4TGThaP9tusFfw)
 
 **Apache EventMesh** is a fully serverless platform used to build distributed [event-driven](https://en.wikipedia.org/wiki/Event-driven_architecture)  applications. 
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/05-contact.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/05-contact.md
@@ -11,7 +11,7 @@ sidebar_position: 4
 
 | 微信助手                                              | 微信公众号                                    | Slack                                                                                                         |
 |---------------------------------------------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| <img src="/images/contact/wechat-assistant.jpg" width="128"/> | <img src="/images/contact/wechat-official.jpg" width="128"/> | [Join Slack Chat](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1blhcbedu-9b7yvwAQcDs3fddZxnZXag) |
+| <img src="/images/contact/wechat-assistant.jpg" width="128"/> | <img src="/images/contact/wechat-official.jpg" width="128"/> | [Join Slack Chat](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1vpgrvm5u-hh~5H9Aj4TGThaP9tusFfw) |
 
 ## 邮件列表
 


### PR DESCRIPTION
The current link don't work to join. Error: "This link is no longer active" 

The new link is from https://github.com/apache/eventmesh#community