### PR TITLE
[ISSUE #106] Fix markdown formatting errors and remove duplicate content

### DIFF
--- a/community/contribute/01-contribute.md
+++ b/community/contribute/01-contribute.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 
 # How to Contribute
 
-If you are a new contributor who wants to contribute to the eventmesh community, please read this document, which describes how to contribute to the community, and if you find any questions in the document, feel free to leave comments or suggestions.
+If you are a new contributor who wants to contribute to the EventMesh community, please read this document, which describes how to contribute to the community, and if you find any questions in the document, feel free to leave comments or suggestions.
 
 ## Preparation
 
@@ -90,45 +90,45 @@ So fork the original EventMesh repository into your own repository.
 
 ### Implementation of functions, refactoring
 
-- If you plan to implement a new feature (or refactoring), be sure to communicate with the eventmesh core development team via an Issue or other means, and describe the new feature (or refactoring), mechanism and scenario in detail during the communication process.
+- If you plan to implement a new feature (or refactoring), be sure to communicate with the EventMesh core development team via an Issue or other means, and describe the new feature (or refactoring), mechanism and scenario in detail during the communication process.
 
 ### Documentation Improvement
 
-- You can find the eventmesh documentation at [eventmesh-docs](https://eventmesh.apache.org/docs/introduction), and the documentation is supplemented or improved in a way that is also essential for eventmesh.
+- You can find the EventMesh documentation at [eventmesh-site](https://github.com/apache/eventmesh-site), and the documentation is supplemented or improved in a way that is also essential for EventMesh.
 
 ## Contribution method
 
-There are two ways for new contributors to contribute to the eventmesh community:
+There are two ways for new contributors to contribute to the EventMesh community:
 
-- If you find a bug in the eventmesh code that you want to fix, or if you provide a new feature for the eventmesh, submit an issue in the eventmesh and submit a pr to the eventmesh.
+- If you find a bug in the EventMesh code that you want to fix, or if you provide a new feature for the EventMesh, submit an issue in the EventMesh and submit a PR to the EventMesh.
 
-- Other contributors in the eventmesh community have raised issues, the [`issue for first-time contributors`](https://github.com/apache/incubator-eventmesh/issues/888) sorted out by the community here are relatively simple PR, which can help you familiarize yourself with the process of making contributions to the eventmesh community.
+- Other contributors in the EventMesh community have raised issues, the [`issue for first-time contributors`](https://github.com/apache/eventmesh/issues/888) sorted out by the community here are relatively simple PR, which can help you familiarize yourself with the process of making contributions to the EventMesh community.
 
 ## Submit issue guidelines
 
-- If you don't know how to raise an issue on eventmesh, please read [about the issue](https://docs.github.com/cn/issues/tracking-your-work-with-issues/quickstart).
+- If you don't know how to raise an issue on EventMesh, please read [about the issue](https://docs.github.com/cn/issues/tracking-your-work-with-issues/quickstart).
 
-- In the eventmesh community, there are issue templates that can be used for reference, if the type matches please use the template, if the issue template does not meet your requirements, you can open an empty issue template, for the issue please bring its matching feature labels.
+- In the EventMesh community, there are issue templates that can be used for reference, if the type matches please use the template, if the issue template does not meet your requirements, you can open an empty issue template, for the issue please bring its matching feature labels.
 
 - For the name of the issue, please briefly describe your question or purpose in one sentence, and write in English for better global communication.
 
-##  pull request (pr) submission guidelines
+##  Pull Request (PR) submission guidelines
 
-- If you don't know how to initiate a pr for eventmesh, please see [about pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+- If you don't know how to initiate a PR for EventMesh, please see [about Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
-- Whether it's a bug fix, or a new feature development (if this pr is a new feature development, then documentation updates about the new feature should be included in this pr), please submit a PR to the current development branch master.
+- Whether it's a bug fix, or a new feature development (if this PR is a new feature development, then documentation updates about the new feature should be included in this PR), please submit a PR to the current development branch master.
 
-- The pr submission should follow the template provided by eventmesh as well as the need to write the submission information, a brief description of what the pr you are submitting does is sufficient, please see the [template for details](https://github.com/apache/incubator-eventmesh/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
+- The PR submission should follow the template provided by EventMesh as well as the need to write the submission information, a brief description of what the PR you are submitting does is sufficient, please see the [template for details](https://github.com/apache/eventmesh/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
 
-- The pr you submit needs to be associated with the issue you are fixing, or the issue you are raising,so your PR title should start with [ISSUE #xx].
+- The PR you submit needs to be associated with the issue you are fixing, or the issue you are raising,so your PR title should start with [ISSUE #xx].
 
 - If your change is about a typo or small optimize, you needn't create an Issue, just submit a PR and title with [MINOR].
 
 **Note:**
 
-- A single pull request should not be too large. If heavy changes are required, it's better to separate the changes to a few individual PRs.
+- A single Pull Request should not be too large. If heavy changes are required, it's better to separate the changes to a few individual PRs.
 
-- After creating a PR, one or more committers will help to review the pull request, after approve, this PR will be merged in to eventmesh repository, and the related Issue will be closed.
+- After creating a PR, one or more committers will help to review the Pull Request, after approve, this PR will be merged in to EventMesh repository, and the related Issue will be closed.
 
 ## review
 
@@ -136,7 +136,7 @@ There are two ways for new contributors to contribute to the eventmesh community
 
 All code should be well reviewed by one or more committers. Some principles:
 
-- Readability: Important code should be well-documented. Comply with our [code style](https://github.com/apache/incubator-eventmesh/blob/master/style/checkStyle.xml).
+- Readability: Important code should be well-documented. Comply with our [code style](https://github.com/apache/eventmesh/blob/master/style/checkStyle.xml).
 
 - Elegance: New functions, classes or components should be well-designed.
 
@@ -144,15 +144,13 @@ All code should be well reviewed by one or more committers. Some principles:
 
 ### License review
 
-EventMesh follows [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) policy. All source files should
-have the Apache License header added to the file header. EventMesh uses the [apache/skywalking-eyes](https://github.com/apache/skywalking-eyes) to check
-the source file header.
+EventMesh follows [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) policy. All source files should have the Apache License header added to the file header. EventMesh uses the [apache/skywalking-eyes](https://github.com/apache/skywalking-eyes) to check the source file header.
 
 ### PR merge
 
-After a PR is approved by at least one committer, it can be merged. Before the merge, the committer can make changes to the commits message, requiring the commits
-message to be clear without duplication, and use Squash and Merge to make sure one PR should only contain one commits.
-For large multi-person PR, use Merge to merge, and fix the commits by rebase before merging.
+After a PR is approved by at least one committer, it can be merged. Before the merge, the committer can make changes to the commits message, requiring the commits message to be clear without duplication, and use `Squash` and `Merge` to make sure one PR should only contain one commits.
+
+For large multi-person PR, use `Merge` to merge, and fix the commits by `rebase` before merging.
 
 ## Community
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/contribute/01-contribute.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/contribute/01-contribute.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 
 # 如何贡献
 
-如果你是一个新的贡献者，想为eventmesh社区做贡献，请阅读这篇文档，它描述了如何为社区做贡献，如果你在文档中发现任何问题，请随时发表意见或建议。
+如果你是一个新的贡献者，想为 EventMesh 社区做贡献，请阅读这篇文档，它描述了如何为社区做贡献，如果你在文档中发现任何问题，请随时发表意见或建议。
 
 ## 准备
 
@@ -88,68 +88,56 @@ git rebase upstream_master
 
 ### 错误反馈或错误修复
 
-- 无论是bug反馈还是fix，都需要先创建一个issue，对bug进行详细描述，方便社区通过issue记录方便的查找和查看问题和代码。错误反馈问题通常需要包含对错误信息和可重现场景的完整描述。
+- 无论是 bug 反馈还是 fix，都需要先创建一个 issue，对 bug 进行详细描述，方便社区通过 issue 记录方便的查找和查看问题和代码。错误反馈问题通常需要包含对错误信息和可重现场景的完整描述。
 
 ### 功能实现，重构
 
-- 如果你打算实现一个新特性（或重构），一定要通过Issue或其他方式与eventmesh核心开发团队进行沟通，并在沟通过程中详细描述新特性（或重构）、机制和场景.
+- 如果你打算实现一个新特性（或重构），一定要通过 issue 或其他方式与 EventMesh 核心开发团队进行沟通，并在沟通过程中详细描述新特性（或重构）、机制和场景.
 
 ### 文档改进
 
-- 您可以在 [eventmesh-docs](https://github.com/apache/incubator-eventmesh/tree/master/docs) 找到 eventmesh 文档，文档内容的补充和提升对EventMesh也很重要。
+- 您可以在 [eventmesh-site](https://github.com/apache/eventmesh-site) 找到 EventMesh 文档，文档内容的补充和提升对 EventMesh 也很重要。
 
 ## 贡献方式
 
-新贡献者可以通过两种方式为 eventmesh 社区做出贡献：
+新贡献者可以通过两种方式为 EventMesh 社区做出贡献：
 
-- 如果您在 eventmesh 代码中发现要修复的错误，或者如果您为 eventmesh 提供了新功能，请在 eventmesh 中提交问题并向 eventmesh 提交 pr。
-- eventmesh社区其他贡献者提出了issue，这里社区整理的[`issue for first-time contributors`](https://github.com/apache/incubator-eventmesh/issues/888)比较简单PR，可以帮助你熟悉为eventmesh社区做贡献的过程。
+- 如果您在 EventMesh 代码中发现要修复的错误，或者如果您为 EventMesh 提供了新功能，请在 EventMesh 中提交问题并向 EventMesh 提交 PR。
+- EventMesh 社区其他贡献者提出了 issue，这里社区整理的[`issue for first-time contributors`](https://github.com/apache/eventmesh/issues/888)比较简单 PR，可以帮助你熟悉为 EventMesh 社区做贡献的过程。
 
 ## 提交问题指南
 
-- 如果您不知道如何在 eventmesh 上提出问题，请阅读[关于问题](https://docs.github.com/cn/issues/tracking-your-work-with-issues/quickstart)。
+- 如果您不知道如何在 EventMesh 上提出问题，请阅读[关于问题](https://docs.github.com/cn/issues/tracking-your-work-with-issues/quickstart)。
 
-- 在eventmesh社区，有issue模板可以参考，如果类型匹配请使用模板，如果issue模板不符合你的要求，可以开一个空的issue模板，issue请自带匹配特征标签。
+- 在 EventMesh 社区，有 issue 模板可以参考，如果类型匹配请使用模板，如果 issue 模板不符合你的要求，可以开一个空的 issue 模板，issue 请自带匹配特征标签。
 
 - 问题名称，请用一句话简单描述你的问题或目的，并用英文书写，以便于全球交流。
 
-## 拉取请求 (pr) 提交指南
+## 拉取请求 (PR) 提交指南
 
-- 如果您不知道如何为 eventmesh 发起 pr，请参阅 [关于 pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes -to-your-work-with-pull-requests/creating-a-pull-request)。
+- 如果您不知道如何为 EventMesh 发起 PR，请参阅 [关于 pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)。
 
-- 无论是bug修复，还是新特性开发（如果这个pr是新特性开发，那么这个pr中应该包含新特性的文档更新），请向当前开发分支master提交PR。
+- 无论是 bug 修复，还是新特性开发（如果这个 PR 是新特性开发，那么这个 PR 中应该包含新特性的文档更新），请向当前开发分支 master 提交 PR。
 
-- 提交pr需要遵循eventmesh提供的模板，同时需要写提交信息，简单描述你提交的pr是干什么的就可以了，详见[模板](https://github.com/apache/incubator-eventmesh/blob/master/.github/PULL_REQUEST_TEMPLATE.md)。
+- 提交 PR 需要遵循 EventMesh 提供的模板，同时需要写提交信息，简单描述你提交的 PR 是干什么的就可以了，详见[模板](https://github.com/apache/eventmesh/blob/master/.github/PULL_REQUEST_TEMPLATE.md)。
 
-- 您提交的 pr 需要与您正在修复的问题相关联，或者您正在提出的问题，因此您的 PR 标题应以 [ISSUE #xx] 开头。
+- 您提交的 PR 需要与您正在修复的问题相关联，或者您正在提出的问题，因此您的 PR 标题应以 [ISSUE #xx] 开头。
 
 - 如果您的更改是关于打字错误或小的优化，则无需创建问题，只需提交 PR 和带有 [MINOR] 的标题即可。
 
 **注意：**
 
-- 单个PR提交的修改内容不应过多。如果需要进行大量更改，最好将更改分离到几个单独的 PR。
+- 单个 PR 提交的修改内容不应过多。如果需要进行大量更改，最好将更改分离到几个单独的 PR。
 
-- 创建 PR 后，一个或多个 committer 将帮助审核 pull request，批准后，此 PR 将合并到 eventmesh 仓库，相关 Issue 将被关闭。
-
-## review
-
-### PR review
-
-All code should be well reviewed by one or more committers. Some principles:
-
-- Readability: Important code should be well-documented. Comply with our [code style](https://github.com/apache/incubator-eventmesh/blob/master/style/checkStyle.xml).
-
-- Elegance: New functions, classes or components should be well-designed.
-
-- Testability: Important code should be well-tested (high unit test coverage).
+- 创建 PR 后，一个或多个 committer 将帮助审核 Pull Request，批准后，此 PR 将合并到 EventMesh 仓库，相关 Issue 将被关闭。
 
 ## 审查
 
-### PR审查
+### PR 审查
 
 所有代码都应该由一位或多位提交者仔细审查。一些原则：
 
-- 可读性：重要的代码应该有详细的文档记录。遵守我们的[代码风格](https://github.com/apache/incubator-eventmesh/blob/master/style/checkStyle.xml)。
+- 可读性：重要的代码应该有详细的文档记录。遵守我们的[代码风格](https://github.com/apache/eventmesh/blob/master/style/checkStyle.xml)。
 
 - 优雅：新功能、类或组件应该经过精心设计。
 
@@ -157,12 +145,12 @@ All code should be well reviewed by one or more committers. Some principles:
 
 ### 许可证审查
 
-EventMesh 遵循 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) 政策。所有源文件应该将 Apache 许可证标头添加到文件标头。 EventMesh 使用 [apache/skywalking-eyes](https://github.com/apache/skywalking-eyes) 检查源文件头。
+EventMesh 遵循 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) 政策。所有源文件应该将 Apache 许可证标头添加到文件标头。EventMesh 使用 [apache/skywalking-eyes](https://github.com/apache/skywalking-eyes) 检查源文件头。
 
-### PR合并
+### PR 合并
 
 在一个 PR 被至少一个提交者批准后，它可以被合并。在合并之前，提交者可以更改提交消息，要求提交消息要清晰无重复，并使用 Squash 和 Merge 来确保一个 PR 应该只包含一个提交。
-对于大型多人PR，使用Merge进行合并，合并前通过rebase修复提交。
+对于大型多人 PR，使用 Merge 进行合并，合并前通过 rebase 修复提交。
 
 ## 社区
 


### PR DESCRIPTION
Fixes #106.

- Fixed errors in images.

- Fixed case confusion for proper nouns and acronyms.

- Removed all "incubator"s in contribution guideline.

- Format optimisation.

![image](https://github.com/apache/eventmesh-site/assets/41445332/97490247-3ce3-41a2-9867-935ea65e4952)

![image](https://github.com/apache/eventmesh-site/assets/41445332/080c2c9d-25a0-4131-91e3-7960d07305e4)