### PR TITLE
[ISSUE #109] queryWebHookConfigById endpoint causes NPE and returns empty response & Optimize Hard-coding

### DIFF
--- a/docs/design-document/14-webhook.md
+++ b/docs/design-document/14-webhook.md
@@ -39,6 +39,11 @@ Configuration information description
     private String manufacturerName;
 
     /**
+     * manufacturer domain name, like www.github.com
+     */
+    private String manufacturerDomain;
+
+    /**
      * webhook event name, like rep-push
      */
     private String manufacturerEventName;
@@ -78,12 +83,7 @@ Configuration information description
      * roll out data format -> CloudEvent serialization mode
      * If HTTP protocol is used, the request header contentType needs to be marked
      */
-    private String dataContentType = "application/json";;
-
-    /**
-     * source of event
-     */
-    private String cloudEventSource;
+    private String dataContentType = "application/json";
 
     /**
      * id of cloudEvent, like uuid/manufacturerEventId
@@ -104,15 +104,15 @@ input params:
 | -- | -- | -- | -- | -- |
 | callbackPath | call address, unique address | string | Y　| null　|
 | manufacturerName | manufacturer name | string | Y　| null　|
-| manufacturerEventName | manufacturer EventName  | string | Y　| null　|
+| manufacturerDomain | manufacturer domain name | string | Y　| null　|
+| manufacturerEventName | manufacturer event name | string | Y　| null　|
 | contentType | http connettype | string | N　| application/json　|
 | description | configuration instructions | string | N　| null　|
 | secret | signature string | string | N　| null　|
 | userName | username | string | N　| null　|
 | password | password | string | N　| null　|
 | cloudEventName | cloudEvent name  | string | Y　| null　|
-| cloudEventSource | cloudEvent source | string | Y　| null　|
-| cloudEventIdGenerateMode | cloudEvent event object identification method, uuid or event id  | string | N manufacturerEventId　|
+| cloudEventIdGenerateMode | cloudEvent event object identification method, uuid or event id  | string | N　|manufacturerEventId|
 
 E.g:
 
@@ -155,6 +155,7 @@ Output params:
 | -- | -- | -- | -- | -- |
 | callbackPath | call address, unique address | string | Y　| null　|
 | manufacturerName | manufacturer name | string | Y　| null　|
+| manufacturerDomain | manufacturer domain name | string | Y　| null　|
 | manufacturerEventName | manufacturer event name | string | Y　| null　|
 | contentType | http connettype | string | N　| application/json　|
 | description | configuration instructions | string | N　| null　|
@@ -162,7 +163,6 @@ Output params:
 | userName | user name | string | N　| null　|
 | password | password | string | N　| null　|
 | cloudEventName | cloudEvent name | string | Y　| null　|
-| cloudEventSource | cloudEvent source | string | Y　| null　|
 | cloudEventIdGenerateMode | cloudEvent event object identification method, uuid or event id | string | N　| manufacturerEventId　|
 
 
@@ -194,6 +194,7 @@ Output params:
 | -- | -- | -- | -- | -- |
 | callbackPath | call address, unique address | string | Y　| null　|
 | manufacturerName | manufacturer name | string | Y　| null　|
+| manufacturerDomain | manufacturer domain name | string | Y　| null　|
 | manufacturerEventName | manufacturer event name | string | Y　| null　|
 | contentType | http connettype | string | N　| application/json　|
 | description | configuration instructions | string | N　| null　|
@@ -201,7 +202,6 @@ Output params:
 | userName | user name | string | N　| null　|
 | password | password | string | N　| null　|
 | cloudEventName | cloudEvent name | string | Y　| null　|
-| cloudEventSource | cloudEvent source | string | Y　| null　|
 | cloudEventIdGenerateMode | cloudEvent event object identification method, uuid or event id  | string | N　| manufacturerEventId　|
 
 ##### Delete WebHook config

--- a/docs/design-document/14-webhook.md
+++ b/docs/design-document/14-webhook.md
@@ -92,7 +92,7 @@ Configuration information description
 
 ```
 
-##### Add webhook config
+##### Add WebHook config
 
 path: /webhook/insertWebHookConfig
 method: POST
@@ -117,7 +117,6 @@ input params:
 E.g:
 
 ```json
-
 {
 	"callbackPath":"/webhook/github/eventmesh/all",
 	"manufacturerName":"github",
@@ -126,36 +125,11 @@ E.g:
 	"cloudEventName":"github-eventmesh",
 	"cloudEventSource":"github"
 }
-
 ```
 
 Output params: 1 for success, 0 for failure
 
-##### delete webhook config
-path: /webhook/deleteWebHookConfig
-method: POST
-contentType： application/json
-
-input params:
-
-| field | desc | type |　necessary | default　|
-| -- | -- | -- | -- | -- |
-| callbackPath | call address, unique address | string | Y　| null　|
-
-
-E.g:
-
-```json
-
-{
-	"callbackPath":"/webhook/github/eventmesh/all"
-}
-
-```
-
-Output params: 1 for success, 0 for failure
-
-##### select WebHookConfig by callbackPath
+##### Query WebHook config by callback path
 path: /webhook/queryWebHookConfigById
 method: POST
 contentType： application/json
@@ -165,15 +139,15 @@ input params:
 | field | desc | type |　necessary | default　|
 | -- | -- | -- | -- | -- |
 | callbackPath | call address, unique address | string | Y　| null　|
+| manufacturerName | the provider of this callbackPath belongs to | string | Y　| null　|
 
 E.g:
 
 ```json
-
 {
-	"callbackPath":"/webhook/github/eventmesh/all"
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github"
 }
-
 ```
 
 Output params:
@@ -231,6 +205,30 @@ Output params:
 | cloudEventSource | cloudEvent source | string | Y　| null　|
 | cloudEventIdGenerateMode | cloudEvent event object identification method, uuid or event id  | string | N　| manufacturerEventId　|
 
+##### Delete WebHook config
+
+path: /webhook/deleteWebHookConfig
+method: POST
+contentType： application/json
+
+input params:
+
+| field            | desc                                         | type   | necessary | default |
+| ---------------- | -------------------------------------------- | ------ | --------- | ------- |
+| callbackPath     | call address, unique address                 | string | Y         | null    |
+| manufacturerName | the provider of this callbackPath belongs to | string | Y         | null    |
+
+
+E.g:
+
+```json
+{
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github"
+}
+```
+
+Output params: 1 for success, 0 for failure
 
 #### The third step: Check if the configuration is successful
 
@@ -269,7 +267,6 @@ Output params:
 Payload URL: Service address and pahts. [http or https]://[domain or IP]:[port]/webhook/[callbackPath]
 Content type: http header content type
 secret: signature string
-
 
 
 

--- a/docs/design-document/14-webhook.md
+++ b/docs/design-document/14-webhook.md
@@ -118,12 +118,11 @@ E.g:
 
 ```json
 {
-	"callbackPath":"/webhook/github/eventmesh/all",
-	"manufacturerName":"github",
-	"manufacturerEventName":"all",
-	"secret":"eventmesh",
-	"cloudEventName":"github-eventmesh",
-	"cloudEventSource":"github"
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github",
+    "manufacturerDomain":"www.github.com",
+    "manufacturerEventName":"all",
+    "cloudEventName":"github-eventmesh"
 }
 ```
 

--- a/docs/design-document/14-webhook.md
+++ b/docs/design-document/14-webhook.md
@@ -139,7 +139,7 @@ input params:
 | field | desc | type |　necessary | default　|
 | -- | -- | -- | -- | -- |
 | callbackPath | call address, unique address | string | Y　| null　|
-| manufacturerName | the provider of this callbackPath belongs to | string | Y　| null　|
+| manufacturerName | the caller of this callbackPath belongs to | string | Y　| null　|
 
 E.g:
 
@@ -213,10 +213,10 @@ contentType： application/json
 
 input params:
 
-| field            | desc                                         | type   | necessary | default |
-| ---------------- | -------------------------------------------- | ------ | --------- | ------- |
-| callbackPath     | call address, unique address                 | string | Y         | null    |
-| manufacturerName | the provider of this callbackPath belongs to | string | Y         | null    |
+| field            | desc                                       | type   | necessary | default |
+| ---------------- | ------------------------------------------ | ------ | --------- | ------- |
+| callbackPath     | call address, unique address               | string | Y         | null    |
+| manufacturerName | the caller of this callbackPath belongs to | string | Y         | null    |
 
 
 E.g:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
@@ -136,30 +136,6 @@ contentType： application/json
 ```
 输出参数：１　成功，０失败
 
-##### 删除接口
-路径： /webhook/deleteWebHookConfig
-方法： POST
-contentType： application/json
-
-输入参数：
-| 字段 | 说明 | 类型 |　必须 | 默认值　|
-| -- | -- | -- | -- | -- |
-| callbackPath | 调用地址，唯一地址 | string | 是　| null　|
-
-
-列子：
-
-```json
-
-{
-	"callbackPath":"/webhook/github/eventmesh/all"
-}
-
-```
-
-
-输出参数：１　成功，０失败
-
 ##### 通过callbackPath查询WebHookConfig
 路径： /webhook/queryWebHookConfigById
 方法： POST
@@ -169,16 +145,16 @@ contentType： application/json
 | 字段 | 说明 | 类型 |　必须 | 默认值　|
 | -- | -- | -- | -- | -- |
 | callbackPath | 调用地址，唯一地址 | string | 是　| null　|
+| manufacturerName | 调用地址的提供方 | string | 是　| null　|
 
 
 列子：
 
 ```json
-
 {
-	"callbackPath":"/webhook/github/eventmesh/all"
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github"
 }
-
 ```
 
 
@@ -235,8 +211,34 @@ contentType： application/json
 | cloudEventSource | 事件来源可以填写 | string | 是　| null　|
 | cloudEventIdGenerateMode | cloudEvent事件对象唯一标识符识别方式，uuid或者manufacturerEventId(厂商id)  | string | 否　| manufacturerEventId　|
 
+##### 删除接口
+
+路径： /webhook/deleteWebHookConfig
+方法： POST
+contentType： application/json
+
+输入参数：
+
+| 字段             | 说明               | 类型   | 必须 | 默认值 |
+| ---------------- | ------------------ | ------ | ---- | ------ |
+| callbackPath     | 调用地址，唯一地址 | string | 是   | null   |
+| manufacturerName | 调用地址的提供方   | string | 是   | null   |
+
+
+列子：
+
+```json
+{
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github"
+}
+```
+
+
+输出参数：１　成功，０失败
 
 #### 第三步：查看配置是否成功
+
 1. file存储模式。请到eventMesh.webHook.fileMode.filePath 目录下查看。文件名为callbackPath转移后的
 2. nacos存储模式。请到eventMesh.webHook.nacosMode.serverAddr 配置的nacos服务去看
 
@@ -262,7 +264,6 @@ contentType： application/json
 Payload URL: 服务地址以及pahts。[http or https ]://[域名 or IP 【厂商可以被调用】]:[端口]/webhook/[callbackPath]
 Content type：http header content type
 secret: 验签字符串
-
 
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
@@ -123,16 +123,13 @@ contentType： application/json
 
 列子：
 ```json
-
 {
-	"callbackPath":"/webhook/github/eventmesh/all",
-	"manufacturerName":"github",
-	"manufacturerEventName":"all",
-	"secret":"eventmesh",
-	"cloudEventName":"github-eventmesh",
-	"cloudEventSource":"github"
+    "callbackPath":"/webhook/github/eventmesh/all",
+    "manufacturerName":"github",
+    "manufacturerDomain":"www.github.com",
+    "manufacturerEventName":"all",
+    "cloudEventName":"github-eventmesh"
 }
-
 ```
 输出参数：１　成功，０失败
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/design-document/15-webhook.md
@@ -39,6 +39,12 @@ eventMesh.webHook.producer.connector=standalone
     private String manufacturerName;
 
     /**
+     * 厂商的域名
+     * manufacturer domain name, like www.github.com
+     */
+    private String manufacturerDomain;
+
+    /**
      * 厂商的事件名
      * webhook event name ,like rep-push
      */
@@ -86,12 +92,7 @@ eventMesh.webHook.producer.connector=standalone
      * roll out data format -> CloudEvent serialization mode
      * If HTTP protocol is used, the request header contentType needs to be marked
      */
-    private String dataContentType = "application/json";;
-
-    /**
-     * source of event
-     */
-    private String cloudEventSource;
+    private String dataContentType = "application/json";
 
     /**
      * cloudEvent事件对象唯一标识符识别方式，uuid或者manufacturerEventId(厂商id)
@@ -111,14 +112,14 @@ contentType： application/json
 | -- | -- | -- | -- | -- |
 | callbackPath | 调用地址，唯一地址 | string | 是　| null　|
 | manufacturerName | 厂商名 | string | 是　| null　|
+| manufacturerDomain | 厂商的域名 | string | 是　| null　|
 | manufacturerEventName | 厂商事件名 | string | 是　| null　|
 | contentType | http connettype | string | 否　| application/json　|
 | description | 配置说明 | string | 否　| null　|
 | secret | 验签密钥 | string | 否　| null　|
 | userName | 用户名 | string | 否　| null　|
 | password | 用户密码 | string | 否　| null　|
-| cloudEventName | 事件名（） | string | 是　| null　|
-| cloudEventSource | 事件来源可以填写 | string | 是　| null　|
+| cloudEventName | 事件名 | string | 是　| null　|
 | cloudEventIdGenerateMode | cloudEvent事件对象唯一标识符识别方式，uuid或者manufacturerEventId(厂商id)  | string | 否　| manufacturerEventId　|
 
 列子：
@@ -160,6 +161,7 @@ contentType： application/json
 | -- | -- | -- | -- | -- |
 | callbackPath | 调用地址，唯一地址 | string | 是　| null　|
 | manufacturerName | 厂商名 | string | 是　| null　|
+| manufacturerDomain | 厂商的域名 | string | 是　| null　|
 | manufacturerEventName | 厂商事件名 | string | 是　| null　|
 | contentType | http connettype | string | 否　| application/json　|
 | description | 配置说明 | string | 否　| null　|
@@ -167,7 +169,6 @@ contentType： application/json
 | userName | 用户名 | string | 否　| null　|
 | password | 用户密码 | string | 否　| null　|
 | cloudEventName | 事件名（） | string | 是　| null　|
-| cloudEventSource | 事件来源可以填写 | string | 是　| null　|
 | cloudEventIdGenerateMode | cloudEvent事件对象唯一标识符识别方式，uuid或者manufacturerEventId(厂商id)  | string | 否　| manufacturerEventId　|
 
 
@@ -198,6 +199,7 @@ contentType： application/json
 | -- | -- | -- | -- | -- |
 | callbackPath | 调用地址，唯一地址 | string | 是　| null　|
 | manufacturerName | 厂商名 | string | 是　| null　|
+| manufacturerDomain | 厂商的域名 | string | 是　| null　|
 | manufacturerEventName | 厂商事件名 | string | 是　| null　|
 | contentType | http connettype | string | 否　| application/json　|
 | description | 配置说明 | string | 否　| null　|
@@ -205,7 +207,6 @@ contentType： application/json
 | userName | 用户名 | string | 否　| null　|
 | password | 用户密码 | string | 否　| null　|
 | cloudEventName | 事件名（） | string | 是　| null　|
-| cloudEventSource | 事件来源可以填写 | string | 是　| null　|
 | cloudEventIdGenerateMode | cloudEvent事件对象唯一标识符识别方式，uuid或者manufacturerEventId(厂商id)  | string | 否　| manufacturerEventId　|
 
 ##### 删除接口


### PR DESCRIPTION
Fixes #109.

This is a synchronised modification of this issue: https://github.com/apache/eventmesh/issues/4243

![55b07433e099064891d9a7a68d9e48d](https://github.com/apache/eventmesh-site/assets/41445332/5c9ad421-bb06-4496-a604-82052c90ecb5)

When inserting the config, the path contains `manufacturerName`, and the same logic applies when querying. Therefore, if we follow the request example in the documentation, it will result in an NPE (NullPointerException).

![de668469ccf5d20f22302fc5e2c1863](https://github.com/apache/eventmesh-site/assets/41445332/11bb064e-7cbf-4756-8937-8d242110cbc3)

There are two possible solutions, with no impact on users. One way is to retrieve `manufacturerName` from `callbackPath` when making a query on our end. However, this would require specifying in the documentation that `manufacturerName` must be included in users' `callbackPath`, which doesn't seem like a common practice.

A simpler solution is to include `manufacturerName` in the request. Since there are likely no users for our webhook at the moment, I will go with the latter option.