### PR TITLE
[ISSUE #172] Update Team members

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on:
   pull_request:
-    branches: [master]
+    branches: [ '*' ]
   push:
     branches: [master]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on:
   pull_request:
-    branches: [ '*' ]
+    branches: [master]
   push:
     branches: [master]
 

--- a/i18n/zh/docusaurus-plugin-content-pages/team.md
+++ b/i18n/zh/docusaurus-plugin-content-pages/team.md
@@ -1,48 +1,49 @@
 # 团队成员
 
-Apache EventMesh 由我们的 PPMC、Committer 和其他贡献者开发。无论是对于琐碎的清理，大的新功能，还是其他具有实际价值的贡献，我们都非常感激对 EventMesh 的所有贡献。
+Apache EventMesh 由我们的 PMC、Committer 和其他贡献者开发。无论是对于琐碎的清理，大的新功能，还是其他具有实际价值的贡献，我们都非常感激对 EventMesh 的所有贡献。
 
-## PPMCs & Committers
+## PMCs & Committers
 
 以下是一份具有提交权限并在各种方式上为 EventMesh 做出了巨大贡献的贡献者列表。
 
-|Name| Github Id                                      | Email |[Roles](https://www.apache.org/foundation/how-it-works.html#roles)| Time Zone|
-|:---|:-----------------------------------------------|:---|:---|:--|
-|Francois Papon| [@fpapon](https://github.com/fpapon) |francois.papon@openobject.fr |Mentor| +1|
-|Jean-Baptiste Onofré| [@jbonofre](https://github.com/jbonofre)         |jbonofre@apache.org |Mentor| +1 |
-|Junping Du| [@JunpingDu](https://github.com/JunpingDu)         |junping_du@apache.org |Mentor| +8 |
-|Justin Mclean| [@justinmclean](https://github.com/justinmclean)     |justin@classsoftware.com |Mentor| +10 |
-|Von Gosling| [@vongosling](https://github.com/vongosling)         |vongosling@apache.org  |Mentor| +8 |
-|Guangsheng Chen| [@qqeasonchen](https://github.com/qqeasonchen) |chenguangsheng@apache.org |PPMC Member| +8|
-|Heng Du| [@duhenglucky](https://github.com/duhengforever)         |duhengforever@apache.org |PPMC Member| +8 |
-|Shannon Ding| [@dinglei](https://github.com/dinglei) |dinglei@apache.org |PPMC Member| +8|
-|Weiqiang Liang| [@wqliang](https://github.com/wqliang)         |wqliang@apache.org |PPMC Member| +8 |
-|Weiming Xue| [@xwm1992](https://github.com/xwm1992)         |mikexue@apache.org |PPMC Member| +8 |
-|Wenjun Ruan| [@ruanwenjun](https://github.com/ruanwenjun) |wenjun@apache.org |PPMC Member| +8|
-|Xiaoshuang Li| [@li-xiao-shuang](https://github.com/li-xiao-shuang)         |lixiaoshuang@apache.org |PPMC Member| +8 |
-|Jun Yang| [@jonyangx](https://github.com/jonyangx)         |jonyang@apache.org |Committer| +8 |
-|Ronghua Liang| [@lrhkobe](https://github.com/lrhkobe)         |lrhkobe@apache.org |Committer| +8 |
-|Le Liu| [@walleliu](https://github.com/walleliu)         |walleliu@apache.org |Committer| +8 |
-|Fan He| [@MajorHe1](https://github.com/MajorHe1)         |majorhe@apache.org |Committer| +8 |
-|Hongbing Yan| [@keranbingaa](https://github.com/keranbingaa)         |bingyan@apache.org |Committer| +8 |
-|Mengfei Xiong| [@iNanos](https://github.com/iNanos) |nanoxiong@apache.org |Committer| +8|
-|Xiaoyang Liu| [@xiaoyang-sde](https://github.com/xiaoyang-sde) |xiaoyang@apache.org |Committer| -7|
-|Alex Luo| [@jinrongluo](https://github.com/jinrongluo)         |alexluo@apache.org |Committer| -4 |
-|Jay Taylor| [@githublaohu](https://github.com/githublaohu)         |jie@apache.org |Committer| +8 |
-|Jianbo Mai| [@JellyBo](https://github.com/jellybo)         |jellybo@apache.org |Committer| +8 |
-|YuanXin Hu| [@huyuanxin](https://github.com/huyuanxin)         |huyuanxin@apache.org |Committer| +8 |
-|Yuwei Zhu| [@walterlife](https://github.com/walterlife)         |walterzywei@apache.org |Committer| +8 |
-|Zhou Chen| [@horoc](https://github.com/horoc)         |chenzhou@apache.org |Committer| +8 |
-|Mengyang Tang| [@mytang0](https://github.com/mytang0)         |mytang0@apache.org |Committer| +8 |
-|Pengcheng Ma| [@pchengma](https://github.com/pchengma)         |pchengma@apache.org |Committer| +8 |
-|ShanPeng Qing| [@mroccyen](https://github.com/mroccyen)         |qingshanpeng@apache.org |Committer| +8 |
-|Wei Liu| [@LIU-WEI-git](https://github.com/LIU-WEI-git)         |timcross@apache.org |Committer| +8 |
-|Wei Zou| [@VNBear](https://github.com/VNBear)         |vnbear@apache.org |Committer| +8 |
-|Wentong Shi| [@RiESAEX](https://github.com/RiESAEX)         |xwbx@apache.org |Committer| +8 |
-|Yongshe Feng| [@fengyongshe](https://github.com/fengyongshe)         |fengyongshe@apache.org |Committer| +8 |
-|Mark Li| [@Markliniubility](https://github.com/Markliniubility)         |markli@apache.org |Committer| +8 |
-|Jianbo Liu| [@mxsm](https://github.com/mxsm) |mxsm@apache.org |Committer| +8 |
-|Harshitha Sudhakar| [@harshithasudhakar](https://github.com/harshithasudhakar) |harshitha@apache.org |Committer| +6 |
+| Name                 | Github Id                                                  | Email                        | [Roles](https://www.apache.org/foundation/how-it-works.html#roles) | Time Zone |
+| :------------------- | :--------------------------------------------------------- | :--------------------------- | :----------------------------------------------------------- | :-------- |
+| Francois Papon       | [@fpapon](https://github.com/fpapon)                       | francois.papon@openobject.fr | Mentor                                                       | +1        |
+| Jean-Baptiste Onofré | [@jbonofre](https://github.com/jbonofre)                   | jbonofre@apache.org          | Mentor                                                       | +1        |
+| Junping Du           | [@JunpingDu](https://github.com/JunpingDu)                 | junping_du@apache.org        | Mentor                                                       | +8        |
+| Justin Mclean        | [@justinmclean](https://github.com/justinmclean)           | justin@classsoftware.com     | Mentor                                                       | +10       |
+| Von Gosling          | [@vongosling](https://github.com/vongosling)               | vongosling@apache.org        | Mentor                                                       | +8        |
+| Guangsheng Chen      | [@qqeasonchen](https://github.com/qqeasonchen)             | chenguangsheng@apache.org    | PMC Chair                                                    | +8        |
+| Heng Du              | [@duhenglucky](https://github.com/duhengforever)           | duhengforever@apache.org     | PMC Member                                                   | +8        |
+| Shannon Ding         | [@dinglei](https://github.com/dinglei)                     | dinglei@apache.org           | PMC Member                                                   | +8        |
+| Weiqiang Liang       | [@wqliang](https://github.com/wqliang)                     | wqliang@apache.org           | PMC Member                                                   | +8        |
+| Weiming Xue          | [@xwm1992](https://github.com/xwm1992)                     | mikexue@apache.org           | PMC Member                                                   | +8        |
+| Wenjun Ruan          | [@ruanwenjun](https://github.com/ruanwenjun)               | wenjun@apache.org            | PMC Member                                                   | +8        |
+| Xiaoshuang Li        | [@li-xiao-shuang](https://github.com/li-xiao-shuang)       | lixiaoshuang@apache.org      | PMC Member                                                   | +8        |
+| Jianbo Liu           | [@mxsm](https://github.com/mxsm)                           | mxsm@apache.org              | PMC Member                                                   | +8        |
+| Jun Yang             | [@jonyangx](https://github.com/jonyangx)                   | jonyang@apache.org           | Committer                                                    | +8        |
+| Ronghua Liang        | [@lrhkobe](https://github.com/lrhkobe)                     | lrhkobe@apache.org           | Committer                                                    | +8        |
+| Le Liu               | [@walleliu](https://github.com/walleliu)                   | walleliu@apache.org          | Committer                                                    | +8        |
+| Fan He               | [@MajorHe1](https://github.com/MajorHe1)                   | majorhe@apache.org           | Committer                                                    | +8        |
+| Hongbing Yan         | [@keranbingaa](https://github.com/keranbingaa)             | bingyan@apache.org           | Committer                                                    | +8        |
+| Mengfei Xiong        | [@iNanos](https://github.com/iNanos)                       | nanoxiong@apache.org         | Committer                                                    | +8        |
+| Xiaoyang Liu         | [@xiaoyang-sde](https://github.com/xiaoyang-sde)           | xiaoyang@apache.org          | Committer                                                    | -7        |
+| Alex Luo             | [@jinrongluo](https://github.com/jinrongluo)               | alexluo@apache.org           | Committer                                                    | -4        |
+| Jay Taylor           | [@githublaohu](https://github.com/githublaohu)             | jie@apache.org               | Committer                                                    | +8        |
+| Jianbo Mai           | [@JellyBo](https://github.com/jellybo)                     | jellybo@apache.org           | Committer                                                    | +8        |
+| YuanXin Hu           | [@huyuanxin](https://github.com/huyuanxin)                 | huyuanxin@apache.org         | Committer                                                    | +8        |
+| Yuwei Zhu            | [@walterlife](https://github.com/walterlife)               | walterzywei@apache.org       | Committer                                                    | +8        |
+| Zhou Chen            | [@horoc](https://github.com/horoc)                         | chenzhou@apache.org          | Committer                                                    | +8        |
+| Mengyang Tang        | [@mytang0](https://github.com/mytang0)                     | mytang0@apache.org           | Committer                                                    | +8        |
+| Pengcheng Ma         | [@pchengma](https://github.com/pchengma)                   | pchengma@apache.org          | Committer                                                    | +8        |
+| ShanPeng Qing        | [@mroccyen](https://github.com/mroccyen)                   | qingshanpeng@apache.org      | Committer                                                    | +8        |
+| Wei Liu              | [@LIU-WEI-git](https://github.com/LIU-WEI-git)             | timcross@apache.org          | Committer                                                    | +8        |
+| Wei Zou              | [@VNBear](https://github.com/VNBear)                       | vnbear@apache.org            | Committer                                                    | +8        |
+| Wentong Shi          | [@RiESAEX](https://github.com/RiESAEX)                     | xwbx@apache.org              | Committer                                                    | +8        |
+| Yongshe Feng         | [@fengyongshe](https://github.com/fengyongshe)             | fengyongshe@apache.org       | Committer                                                    | +8        |
+| Mark Li              | [@Markliniubility](https://github.com/Markliniubility)     | markli@apache.org            | Committer                                                    | +8        |
+| Harshitha Sudhakar   | [@harshithasudhakar](https://github.com/harshithasudhakar) | harshitha@apache.org         | Committer                                                    | +6        |
+| Tian Xia             | [@Pil0tXia](https://github.com/Pil0tXia)                   | xiatian@apache.org           | Committer                                                    | +8        |
 
 ## 所有贡献者
 

--- a/src/pages/team.md
+++ b/src/pages/team.md
@@ -6,43 +6,44 @@ The Apache EventMesh is developed by our PMCs, Committers and other Contributors
 
 The following is a list of contributors with commit privileges that have made great contribution to EventMesh in one way or another.
 
-|Name| Github Id                                      | Email |[Roles](https://www.apache.org/foundation/how-it-works.html#roles)| Time Zone|
-|:---|:-----------------------------------------------|:---|:---|:--|
-|Francois Papon| [@fpapon](https://github.com/fpapon) |francois.papon@openobject.fr |PMC Member| +1|
-|Jean-Baptiste Onofré| [@jbonofre](https://github.com/jbonofre)         |jbonofre@apache.org |PMC Member| +1 |
-|Junping Du| [@JunpingDu](https://github.com/JunpingDu)         |junping_du@apache.org |PMC Member| +8 |
-|Justin Mclean| [@justinmclean](https://github.com/justinmclean)     |justin@classsoftware.com |PMC Member| +10 |
-|Von Gosling| [@vongosling](https://github.com/vongosling)         |vongosling@apache.org  |PMC Member| +8 |
-|Guangsheng Chen| [@qqeasonchen](https://github.com/qqeasonchen) |chenguangsheng@apache.org |PMC Chair| +8|
-|Heng Du| [@duhenglucky](https://github.com/duhengforever)         |duhengforever@apache.org |PMC Member| +8 |
-|Shannon Ding| [@dinglei](https://github.com/dinglei) |dinglei@apache.org |PMC Member| +8|
-|Weiqiang Liang| [@wqliang](https://github.com/wqliang)         |wqliang@apache.org |PMC Member| +8 |
-|Weiming Xue| [@xwm1992](https://github.com/xwm1992)         |mikexue@apache.org |PMC Member| +8 |
-|Wenjun Ruan| [@ruanwenjun](https://github.com/ruanwenjun) |wenjun@apache.org |PMC Member| +8|
-|Xiaoshuang Li| [@li-xiao-shuang](https://github.com/li-xiao-shuang)         |lixiaoshuang@apache.org |PMC Member| +8 |
-|Jun Yang| [@jonyangx](https://github.com/jonyangx)         |jonyang@apache.org |Committer| +8 |
-|Ronghua Liang| [@lrhkobe](https://github.com/lrhkobe)         |lrhkobe@apache.org |Committer| +8 |
-|Le Liu| [@walleliu](https://github.com/walleliu)         |walleliu@apache.org |Committer| +8 |
-|Fan He| [@MajorHe1](https://github.com/MajorHe1)         |majorhe@apache.org |Committer| +8 |
-|Hongbing Yan| [@keranbingaa](https://github.com/keranbingaa)         |bingyan@apache.org |Committer| +8 |
-|Mengfei Xiong| [@iNanos](https://github.com/iNanos) |nanoxiong@apache.org |Committer| +8|
-|Xiaoyang Liu| [@xiaoyang-sde](https://github.com/xiaoyang-sde) |xiaoyang@apache.org |Committer| -7|
-|Alex Luo| [@jinrongluo](https://github.com/jinrongluo)         |alexluo@apache.org |Committer| -4 |
-|Jay Taylor| [@githublaohu](https://github.com/githublaohu)         |jie@apache.org |Committer| +8 |
-|Jianbo Mai| [@JellyBo](https://github.com/jellybo)         |jellybo@apache.org |Committer| +8 |
-|YuanXin Hu| [@huyuanxin](https://github.com/huyuanxin)         |huyuanxin@apache.org |Committer| +8 |
-|Yuwei Zhu| [@walterlife](https://github.com/walterlife)         |walterzywei@apache.org |Committer| +8 |
-|Zhou Chen| [@horoc](https://github.com/horoc)         |chenzhou@apache.org |Committer| +8 |
-|Mengyang Tang| [@mytang0](https://github.com/mytang0)         |mytang0@apache.org |Committer| +8 |
-|Pengcheng Ma| [@pchengma](https://github.com/pchengma)         |pchengma@apache.org |Committer| +8 |
-|ShanPeng Qing| [@mroccyen](https://github.com/mroccyen)         |qingshanpeng@apache.org |Committer| +8 |
-|Wei Liu| [@LIU-WEI-git](https://github.com/LIU-WEI-git)         |timcross@apache.org |Committer| +8 |
-|Wei Zou| [@VNBear](https://github.com/VNBear)         |vnbear@apache.org |Committer| +8 |
-|Wentong Shi| [@RiESAEX](https://github.com/RiESAEX)         |xwbx@apache.org |Committer| +8 |
-|Yongshe Feng| [@fengyongshe](https://github.com/fengyongshe)         |fengyongshe@apache.org |Committer| +8 |
-|Mark Li| [@Markliniubility](https://github.com/Markliniubility)         |markli@apache.org |Committer| +8 |
-|Jianbo Liu| [@mxsm](https://github.com/mxsm) |mxsm@apache.org |Committer| +8 |
-|Harshitha Sudhakar| [@harshithasudhakar](https://github.com/harshithasudhakar) |harshitha@apache.org |Committer| +6 |
+| Name                 | Github Id                                                  | Email                        | [Roles](https://www.apache.org/foundation/how-it-works.html#roles) | Time Zone |
+| :------------------- | :--------------------------------------------------------- | :--------------------------- | :----------------------------------------------------------- | :-------- |
+| Francois Papon       | [@fpapon](https://github.com/fpapon)                       | francois.papon@openobject.fr | Mentor                                                       | +1        |
+| Jean-Baptiste Onofré | [@jbonofre](https://github.com/jbonofre)                   | jbonofre@apache.org          | Mentor                                                       | +1        |
+| Junping Du           | [@JunpingDu](https://github.com/JunpingDu)                 | junping_du@apache.org        | Mentor                                                       | +8        |
+| Justin Mclean        | [@justinmclean](https://github.com/justinmclean)           | justin@classsoftware.com     | Mentor                                                       | +10       |
+| Von Gosling          | [@vongosling](https://github.com/vongosling)               | vongosling@apache.org        | Mentor                                                       | +8        |
+| Guangsheng Chen      | [@qqeasonchen](https://github.com/qqeasonchen)             | chenguangsheng@apache.org    | PMC Chair                                                    | +8        |
+| Heng Du              | [@duhenglucky](https://github.com/duhengforever)           | duhengforever@apache.org     | PMC Member                                                   | +8        |
+| Shannon Ding         | [@dinglei](https://github.com/dinglei)                     | dinglei@apache.org           | PMC Member                                                   | +8        |
+| Weiqiang Liang       | [@wqliang](https://github.com/wqliang)                     | wqliang@apache.org           | PMC Member                                                   | +8        |
+| Weiming Xue          | [@xwm1992](https://github.com/xwm1992)                     | mikexue@apache.org           | PMC Member                                                   | +8        |
+| Wenjun Ruan          | [@ruanwenjun](https://github.com/ruanwenjun)               | wenjun@apache.org            | PMC Member                                                   | +8        |
+| Xiaoshuang Li        | [@li-xiao-shuang](https://github.com/li-xiao-shuang)       | lixiaoshuang@apache.org      | PMC Member                                                   | +8        |
+| Jianbo Liu           | [@mxsm](https://github.com/mxsm)                           | mxsm@apache.org              | PMC Member                                                   | +8        |
+| Jun Yang             | [@jonyangx](https://github.com/jonyangx)                   | jonyang@apache.org           | Committer                                                    | +8        |
+| Ronghua Liang        | [@lrhkobe](https://github.com/lrhkobe)                     | lrhkobe@apache.org           | Committer                                                    | +8        |
+| Le Liu               | [@walleliu](https://github.com/walleliu)                   | walleliu@apache.org          | Committer                                                    | +8        |
+| Fan He               | [@MajorHe1](https://github.com/MajorHe1)                   | majorhe@apache.org           | Committer                                                    | +8        |
+| Hongbing Yan         | [@keranbingaa](https://github.com/keranbingaa)             | bingyan@apache.org           | Committer                                                    | +8        |
+| Mengfei Xiong        | [@iNanos](https://github.com/iNanos)                       | nanoxiong@apache.org         | Committer                                                    | +8        |
+| Xiaoyang Liu         | [@xiaoyang-sde](https://github.com/xiaoyang-sde)           | xiaoyang@apache.org          | Committer                                                    | -7        |
+| Alex Luo             | [@jinrongluo](https://github.com/jinrongluo)               | alexluo@apache.org           | Committer                                                    | -4        |
+| Jay Taylor           | [@githublaohu](https://github.com/githublaohu)             | jie@apache.org               | Committer                                                    | +8        |
+| Jianbo Mai           | [@JellyBo](https://github.com/jellybo)                     | jellybo@apache.org           | Committer                                                    | +8        |
+| YuanXin Hu           | [@huyuanxin](https://github.com/huyuanxin)                 | huyuanxin@apache.org         | Committer                                                    | +8        |
+| Yuwei Zhu            | [@walterlife](https://github.com/walterlife)               | walterzywei@apache.org       | Committer                                                    | +8        |
+| Zhou Chen            | [@horoc](https://github.com/horoc)                         | chenzhou@apache.org          | Committer                                                    | +8        |
+| Mengyang Tang        | [@mytang0](https://github.com/mytang0)                     | mytang0@apache.org           | Committer                                                    | +8        |
+| Pengcheng Ma         | [@pchengma](https://github.com/pchengma)                   | pchengma@apache.org          | Committer                                                    | +8        |
+| ShanPeng Qing        | [@mroccyen](https://github.com/mroccyen)                   | qingshanpeng@apache.org      | Committer                                                    | +8        |
+| Wei Liu              | [@LIU-WEI-git](https://github.com/LIU-WEI-git)             | timcross@apache.org          | Committer                                                    | +8        |
+| Wei Zou              | [@VNBear](https://github.com/VNBear)                       | vnbear@apache.org            | Committer                                                    | +8        |
+| Wentong Shi          | [@RiESAEX](https://github.com/RiESAEX)                     | xwbx@apache.org              | Committer                                                    | +8        |
+| Yongshe Feng         | [@fengyongshe](https://github.com/fengyongshe)             | fengyongshe@apache.org       | Committer                                                    | +8        |
+| Mark Li              | [@Markliniubility](https://github.com/Markliniubility)     | markli@apache.org            | Committer                                                    | +8        |
+| Harshitha Sudhakar   | [@harshithasudhakar](https://github.com/harshithasudhakar) | harshitha@apache.org         | Committer                                                    | +6        |
+| Tian Xia             | [@Pil0tXia](https://github.com/Pil0tXia)                   | xiatian@apache.org           | Committer                                                    | +8        |
 
 ## All Contributors
 


### PR DESCRIPTION
Fixes #172

Modification:

- Update PPMC to PMC in CN doc
- Update 'PMC Member' to 'Mentor' in CN doc according to EN doc
- Add new committer (Tian Xia) and PMC member (Jianbo Liu)
- Format the source code of the sheet.
