### PR TITLE
[ISSUE #197] Line endings of shell scripts are still CRLF and need conversion

### DIFF
--- a/docs/instruction/03-runtime.md
+++ b/docs/instruction/03-runtime.md
@@ -97,6 +97,8 @@ bash bin/stop.sh
 
 When the script prints `shutdown server ok!`, it means EventMesh Runtime has stopped.
 
+> In this version, you may need to use `dos2unix` to convert the CRLF line endings of the script to LF line endings.
+
 ## 2. Build Binary Distribution
 
 ### 2.1 Environment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.10.0/instruction/03-runtime.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.10.0/instruction/03-runtime.md
@@ -97,6 +97,8 @@ bash bin/stop.sh
 
 脚本打印`shutdown server ok!`时，代表 EventMesh Runtime 已停止。
 
+> 在此版本，你可能需要使用`dos2unix`将脚本的 CRLF 换行转换到 LF 换行。
+
 ## 2. 构建二进制分发包
 
 ### 2.1 环境


### PR DESCRIPTION
Fixes #197

The shell scripts in 1.10.0 release still have CRLF line breaks, which can not be executed under Unix system without conversion.