### PR TITLE
[ISSUE #217] Add license check instructions in publish guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,120 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Bug report
+title: "[Bug] Bug title "
+description: If something isn't working as expected.
+labels: [ "bug" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: dropdown
+    attributes:
+      label: Environment
+      description: Describe the environment.
+      options:
+        - Mac
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: EventMesh version
+      description: Describe the EventMesh version.
+      options:
+        - master
+        - 1.10.0
+        - 1.9.0
+        - 1.8.0
+        - 1.7.0
+        - 1.6.0
+        - 1.5.0
+        - 1.4.0
+        - 1.3.0
+        - 1.2.0
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What happened
+      description: Describe what happened.
+      placeholder: >
+        A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      description: >
+        Describe the steps to reproduce the bug here.
+      placeholder: >
+        Please make sure you provide a reproducible step-by-step case of how to reproduce the problem
+        as minimally and precisely as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Debug logs
+      description: Anything else we need to know?
+      placeholder: >
+        Add your debug logs here.
+      render: Java
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: >
+        The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it..
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct) *
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/documentation_related.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_related.yml
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Documentation Related
+title: "[Doc] Documentation Related "
+description: I find some issues related to the documentation.
+labels: [ "documentation" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Documentation Related
+      description: Describe the suggestion about document.
+      placeholder: >
+        e.g There is a typo
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: >
+        The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it..
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct) *
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,0 +1,77 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Enhancement Request
+title: "[Enhancement] Enhancement title"
+description: I want to suggest an enhancement for this project
+labels: [ "enhancement" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Enhancement Request
+      description: Describe the suggestion.
+      placeholder: >
+        First of all: Have you checked the docs https://github.com/apache/eventmesh/tree/develop/docs,
+        or GitHub issues whether someone else has already reported your issue?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: Describe the suggestion.
+      placeholder: >
+        A clear and concise description of what you want to happen. Add any considered drawbacks.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: >
+        The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it..
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct) *
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Feature Request
+title: "[Feature] Feature title "
+description: I want to suggest a feature for this project.
+labels: [ "feature" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Feature Request
+      description: Describe the feature.
+      placeholder: >
+        First of all: Have you checked the docs https://github.com/apache/eventmesh/tree/develop/docs,
+        or GitHub issues whether someone else has already reported your issue?
+        Maybe the feature already exists?
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: >
+        The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it..
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct) *
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Question
+title: "[Question] Question title "
+description: I have a question that isn't answered in docs or issue.
+labels: [ "question" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: Describe your question.
+      placeholder: >
+        Describe your question here :D
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/unit_test.yml
+++ b/.github/ISSUE_TEMPLATE/unit_test.yml
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Unit Test
+title: "[Unit Test] Unit test title"
+description: I want to do some unit tests for this project
+labels: [ "testing" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For better global communication, Please write in English.
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue)
+        first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/apache/eventmesh/issues?q=is%3Aissue) and found
+            no similar issues.
+          required: true
+
+  - type: checkboxes
+    attributes:
+      label: Read the unit testing guidelines
+      description: >
+        Read the [unit testing guidelines](https://eventmesh.apache.org/community/contribute/write-unit-test) before writing unit test code.
+      options:
+        - label: >
+            I have read.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Unit test request
+      description: Describe the unit test.
+      placeholder: >
+        First of all: Have you checked the docs https://github.com/apache/eventmesh/tree/develop/docs,
+        or GitHub issues whether someone else has already reported your issue?
+        Maybe the unit tests you want to do have already been done?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the unit tests you want to do
+      description: Describe the unit test.
+      value: |
+        Module name:
+        Located at:
+        Task status: ×(unfinished) / √(finished)
+        | Task Status | Class | Type |
+        | :------: | :------ | :------ |
+        | × | xxxxxx | xxxxxx |
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix.
+      options:
+        - label: Yes I am willing to submit a PR!
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+### Contribution Checklist
+
+  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
+    where *XXXX* should be replaced by the actual issue number.
+    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.
+
+  - Fill out the template below to describe the changes contributed by the pull request. 
+    That will give reviewers the context they need to do the review.
+  
+  - Each pull request should address only one issue. 
+    Please do not mix up code from multiple issues.
+  
+  - Each commit in the pull request should have a meaningful commit message.
+
+  - Once all items of the checklist are addressed, remove the above text and this checklist, 
+    leaving only the filled out template below.
+
+(The sections below can be removed for hotfixes of typos)
+-->
+
+<!--
+(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
+-->
+
+Fixes #issue_id
+
+### Motivation
+
+*Explain the content here.*
+*Explain why you want to make the changes and what problem you're trying to solve.*
+
+### Modifications
+
+*Describe the modifications you've done.*
+
+### Documentation
+
+- Does this pull request introduce a new feature? (yes / no)
+- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
+- If a feature is not applicable for documentation, explain why?
+- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation

--- a/community/04-release.md
+++ b/community/04-release.md
@@ -291,7 +291,7 @@ $ mkdir ${release_version}-${rc_version}
 
 #### 4.1 Create tags
 
-Create a tag on `${release_version}-release` branch, with rc version, which is a pre-release version
+Create a tag on `${release_version}-prepare` branch, with rc version, which is a pre-release version
 
 ```shell
 $ git tag -a v{$release_version}-{$rc_version} -m "Tagging the ${release_version} first Release Candidate (Candidates start at zero)"
@@ -561,15 +561,15 @@ ${Your EventMesh Release Manager}
 
 ### 1. Merging code branch
 
-Merge the changes of the `${release_version}-release` branch to the `master` branch, delete the `release` branch after the merge is complete
+Merge the changes of the `${release_version}-prepare` branch to the `master` branch, delete the `release` branch after the merge is complete
 
 ```shell
 $ git checkout master
-$ git merge origin/${release_version}-release
+$ git merge origin/${release_version}-prepare
 $ git pull
 $ git push origin master
-$ git push --delete origin ${release_version}-release
-$ git branch -d ${release_version}-release
+$ git push --delete origin ${release_version}-prepare
+$ git branch -d ${release_version}-prepare
 ```
 
 ### 2. Migrating source and binary packages

--- a/community/04-release.md
+++ b/community/04-release.md
@@ -310,18 +310,21 @@ $ tar -czvf apache-eventmesh-${release_version}-source.tar.gz apache-eventmesh-$
 
 #### 4.3 Build binary package
 
-> Compile the source code packaged in the previous step
+> Package the binary release on the `${release_version}-prepare` branch.
 
-Check the compiled file naming format, name the binary as `apache-eventmesh-${release_version}`
-
-> Note: You need to copy the `NOTICE` file in the root directory of the source code, the `DISCLAIMER-WIP` file and the `LICENSE` file in the `tools/third-party-licenses` directory to the binary package
+> Note: The `dist` task depends on `generateDistLicense` and `generateDistNotice` tasks, which will automatically generate `LICENSE` and `NOTICE` files under the `tools/dist-licenses` directory. The `dist` task itself will copy the contents from the `tools/dist-licenses` directory to the `/dist` directory.
 
 ```shell
-$ gradle clean jar dist && gradle installPlugin && gradle tar -x test
+$ ./gradlew clean dist && ./gradlew installPlugin
+```
+
+Check the compiled file naming, renaming the `/dist` directory to `apache-eventmesh-${release_version}`.
+
+```shell
 $ tar -czvf apache-eventmesh-${release_version}-bin.tar.gz apache-eventmesh-${release_version}
 ```
 
-Compress the source package and bin package, and copy the relevant compressed packages to the svn local warehouse directory `/apache/eventmesh/${release_version}-${rc_version}`
+Compress the source package and the binary package, and copy the relevant compressed packages to the local SVN repository under `/apache/eventmesh/${release_version}-${rc_version}`.
 
 ### 5. Generate signature/sha512 file
 
@@ -332,7 +335,7 @@ $ for i in *.tar.gz; do echo $i; gpg --print-md SHA512 $i > $i.sha512 ; done #co
 $ for i in *.tar.gz; do echo $i; gpg --armor --output $i.asc --detach-sig $i ; done #compute signature
 ```
 
-### 6. Commit to Apache svn
+### 6. Commit to Apache SVN
 
 ```shell
 $ cd ~/apache/eventmesh # eventmesh svn root directory
@@ -412,39 +415,26 @@ $ gpg --verify apache-eventmesh-${release_version}-bin.tar.gz.asc apache-eventme
 
 ### 2. Check the file content of the source package
 
-Unzip `apache-eventmesh-${release_version}-source.tar.gz` and check as follows:
+Extract `apache-eventmesh-${release_version}-source.tar.gz` and perform the following checks:
 
-- Check whether the source package contains unnecessary files, causing the tar package to be too large
-
-- Presence of `LICENSE` and `NOTICE` files
-- Existence of `DISCLAIMER` file
-- correct year in `NOTICE` file
-- Only text files exist, no binary files exist
-- All files start with ASF license
-- It can be compiled correctly and the unit test can pass (./gradle build) (currently supports JAVA 8/gradle 7.0/idea 2021.1.1 and above)
-- Check for redundant files or folders, such as empty folders, etc.
+- Check if the source package contains unnecessary files that make the tar package too large.
+- Ensure the existence of `LICENSE` and `NOTICE` files.
+- Verify that the year in the `NOTICE` file is correct.
+- Verify that only text files exist and there are no binary files.
+- Ensure that all files begin with the ASF license (use `license-eye header check` command of the `skywalking-eyes` tool for verification).
+- Ensure successful compilation, passing unit tests (`./gradlew build`) (currently supporting JAVA 8/gradle 7.0/idea 2021.1.1 and above).
+- Check for any redundant files or folders, such as empty folders.
 
 ### 3. Check the file content of the binary package
 
-- Presence of `LICENSE` and `NOTICE` files
-
-- Existence of `DISCLAIMER` file
-
-- correct year in `NOTICE` file
-
-- All text files start with ASF license
-
-- Check third-party dependent licenses:
-
-  - Compatibility with 3rd party dependent licenses
-
-  - All 3rd party dependent licenses are declared in the `LICENSE` file
-
-  - The full versions of the dependent licenses are all in the `license` directory
-
-  - If you are relying on the Apache license and there are `NOTICE` files, then these `NOTICE` files also need to be added to the version `NOTICE` file
-
-You can refer to this article: [ASF third-party license policy](https://apache.org/legal/resolved.html)
+- Ensure the existence of `LICENSE` and `NOTICE` files.
+- Verify that the year in the `NOTICE` file is correct.
+- Ensure that all text files begin with the ASF license (use `license-eye header check` command of the `skywalking-eyes` tool for verification).
+- According to the [ASF 3RD PARTY LICENSE POLICY](https://apache.org/legal/resolved.html), check the licenses of third-party dependencies:
+  - Ensure third-party dependencies' licenses are compatible with Apache-2.0 (run the `checkDeniedLicense` task, focusing on the compatibility of newly added license files under the `tools/dist-licenses` directory).
+  - Ensure all third-party dependencies' licenses are declared in the `LICENSE` file.
+  - Ensure the complete versions of dependency licenses are in the `license` directory (pay attention to the warning logs of the `generateDistLicense` task and supplement the license content of outdated artifacts).
+  - If the dependency is under the Apache license and there is a `NOTICE` file, include these `NOTICE` files in the version's `NOTICE` file.
 
 ## Initiates a vote
 

--- a/community/04-release.md
+++ b/community/04-release.md
@@ -312,7 +312,7 @@ $ tar -czvf apache-eventmesh-${release_version}-source.tar.gz apache-eventmesh-$
 
 > Package the binary release on the `${release_version}-prepare` branch.
 
-> Note: The `dist` task depends on `generateDistLicense` and `generateDistNotice` tasks, which will automatically generate `LICENSE` and `NOTICE` files under the `tools/dist-licenses` directory. The `dist` task itself will copy the contents from the `tools/dist-licenses` directory to the `/dist` directory.
+> Note: The `dist` task depends on `generateDistLicense` and `generateDistNotice` tasks, which will automatically generate `LICENSE` and `NOTICE` files under the `tools/dist-license` directory. The `dist` task itself will copy the contents from the `tools/dist-license` directory to the `/dist` directory.
 
 ```shell
 $ ./gradlew clean dist && ./gradlew installPlugin
@@ -431,10 +431,10 @@ Extract `apache-eventmesh-${release_version}-source.tar.gz` and perform the foll
 - Verify that the year in the `NOTICE` file is correct.
 - Ensure that all text files begin with the ASF license (use `license-eye header check` command of the `skywalking-eyes` tool for verification).
 - According to the [ASF 3RD PARTY LICENSE POLICY](https://apache.org/legal/resolved.html), check the licenses of third-party dependencies:
-  - Ensure third-party dependencies' licenses are compatible with Apache-2.0 (run the `checkDeniedLicense` task, focusing on the compatibility of newly added license files under the `tools/dist-licenses` directory).
+  - Ensure third-party dependencies' licenses are compatible with Apache-2.0 (run the `checkDeniedLicense` task, focusing on the compatibility of newly added license files under the `tools/dist-license` directory).
   - Ensure all third-party dependencies' licenses are declared in the `LICENSE` file.
-  - Ensure the complete versions of dependency licenses are in the `license` directory (pay attention to the warning logs of the `generateDistLicense` task and supplement the license content of outdated artifacts).
-  - If the dependency is under the Apache license and there is a `NOTICE` file, include these `NOTICE` files in the version's `NOTICE` file.
+  - Ensure the complete versions of dependency licenses are in the `licenses` directory (pay attention to the warning logs of the `generateDistLicense` task and supplement the license content of outdated artifacts).
+  - If the dependency is under the Apache license and there is a `NOTICE` file, include these `NOTICE` files' content in EventMesh's `NOTICE` file.
 
 ## Initiates a vote
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
@@ -418,26 +418,22 @@ $ gpg --verify apache-eventmesh-${release_version}-bin.tar.gz.asc apache-eventme
 
 - 检查源码包是否包含由于包含不必要文件，致使tar包过于庞大
 - 存在`LICENSE`和`NOTICE`文件
-- 存在`DISCLAIMER`文件
 - `NOTICE`文件中的年份正确
 - 只存在文本文件，不存在二进制文件
-- 所有文件的开头都有ASF许可证
-- 能够正确编译，单元测试可以通过 (./gradle build) (目前支持JAVA 8/gradle 7.0/idea 2021.1.1及以上)
+- 所有文件的开头都有ASF许可证 (可以使用skywalking-eyes工具的`license-eye header check`命令检查)
+- 能够正确编译，单元测试可以通过 (`./gradlew build`) (目前支持JAVA 8/gradle 7.0/idea 2021.1.1及以上)
 - 检查是否有多余文件或文件夹，例如空文件夹等
 
 ### 3.检查二进制包的文件内容
 
 - 存在`LICENSE`和`NOTICE`文件
-- 存在`DISCLAIMER`文件
 - `NOTICE`文件中的年份正确
-- 所有文本文件开头都有ASF许可证
-- 检查第三方依赖许可证：
-  - 第三方依赖的许可证兼容
+- 所有文本文件开头都有ASF许可证 (可以使用skywalking-eyes工具的`license-eye header check`命令检查)
+- 根据[ASF第三方许可证政策](https://apache.org/legal/resolved.html)，检查第三方依赖的许可证：
+  - 第三方依赖的许可证与Apache-2.0兼容 (运行`checkDeniedLicense `任务，关注`tools/dist-licenses`目录下新增的license文件的兼容性)
   - 所有第三方依赖的许可证都在`LICENSE`文件中声名
-  - 依赖许可证的完整版全部在`license`目录
+  - 依赖许可证的完整版全部在`license`目录 (关注`generateDistLicense`任务的日志警告，补充过时工件的license内容)
   - 如果依赖的是Apache许可证并且存在`NOTICE`文件，那么这些`NOTICE`文件也需要加入到版本的`NOTICE`文件中
-
-你可以参考此文章：[ASF第三方许可证政策](https://apache.org/legal/resolved.html)
 
 ## 发起投票
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
@@ -311,14 +311,17 @@ $ tar -czvf apache-eventmesh-${release_version}-source.tar.gz apache-eventmesh-$
 
 #### 4.3 打包二进制
 
-> 编译上一步打包的源码
+> 在`${release_version}-prepare`分支上打包二进制发行版
 
-检查编译后的文件命名，将二进制文件命名为`apache-eventmesh-${release_version}`
-
-> 注：需将源码根目录下的`DISCLAIMER-WIP`文件以及`tools/third-party-licenses`目录下的`LICENSE`, `NOTICE`文件拷贝到二进制的包中
+> 注：`dist`任务所依赖的`generateDistLicense`和`generateDistNotice`任务将会自动生成`tools/dist-licenses`目录下的`LICENSE`, `NOTICE`文件和`licenses`目录。`dist`任务本身将会复制`tools/dist-licenses`目录下的内容到`/dist`目录下。
 
 ```shell
-$ gradle clean jar dist && gradle installPlugin && gradle tar -x test
+$ ./gradlew clean dist && ./gradlew installPlugin
+```
+
+检查编译后的文件命名，将`/dist`目录命名为`apache-eventmesh-${release_version}`
+
+```shell
 $ tar -czvf apache-eventmesh-${release_version}-bin.tar.gz apache-eventmesh-${release_version}
 ```
 
@@ -333,15 +336,13 @@ $ for i in *.tar.gz; do echo $i; gpg --print-md SHA512 $i > $i.sha512 ; done #�
 $ for i in *.tar.gz; do echo $i; gpg --armor --output $i.asc --detach-sig $i ; done #计算签名
 ```
 
-### 6.提交到Apache svn
+### 6.提交到Apache SVN
 
 ```shell
 $ cd ~/apache/eventmesh # eventmesh svn根目录
 $ svn status
 $ svn commit -m 'prepare for ${release_version}-${rc_version}'
 ```
-
-
 
 ## 验证Release Candidates
 
@@ -436,7 +437,7 @@ $ gpg --verify apache-eventmesh-${release_version}-bin.tar.gz.asc apache-eventme
   - 依赖许可证的完整版全部在`license`目录
   - 如果依赖的是Apache许可证并且存在`NOTICE`文件，那么这些`NOTICE`文件也需要加入到版本的`NOTICE`文件中
 
-你可以参考此文章：[ASF第三方许可证策](https://apache.org/legal/resolved.html)
+你可以参考此文章：[ASF第三方许可证政策](https://apache.org/legal/resolved.html)
 
 ## 发起投票
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
@@ -313,7 +313,7 @@ $ tar -czvf apache-eventmesh-${release_version}-source.tar.gz apache-eventmesh-$
 
 > 在`${release_version}-prepare`分支上打包二进制发行版
 
-> 注：`dist`任务所依赖的`generateDistLicense`和`generateDistNotice`任务将会自动生成`tools/dist-licenses`目录下的`LICENSE`, `NOTICE`文件和`licenses`目录。`dist`任务本身将会复制`tools/dist-licenses`目录下的内容到`/dist`目录下。
+> 注：`dist`任务所依赖的`generateDistLicense`和`generateDistNotice`任务将会自动生成`tools/dist-license`目录下的`LICENSE`, `NOTICE`文件和`licenses`目录。`dist`任务本身将会复制`tools/dist-license`目录下的内容到`/dist`目录下。
 
 ```shell
 $ ./gradlew clean dist && ./gradlew installPlugin
@@ -430,9 +430,9 @@ $ gpg --verify apache-eventmesh-${release_version}-bin.tar.gz.asc apache-eventme
 - `NOTICE`文件中的年份正确
 - 所有文本文件开头都有ASF许可证 (可以使用skywalking-eyes工具的`license-eye header check`命令检查)
 - 根据[ASF第三方许可证政策](https://apache.org/legal/resolved.html)，检查第三方依赖的许可证：
-  - 第三方依赖的许可证与Apache-2.0兼容 (运行`checkDeniedLicense `任务，关注`tools/dist-licenses`目录下新增的license文件的兼容性)
+  - 第三方依赖的许可证与Apache-2.0兼容 (运行`checkDeniedLicense `任务，关注`tools/dist-license`目录下新增的license文件的兼容性)
   - 所有第三方依赖的许可证都在`LICENSE`文件中声名
-  - 依赖许可证的完整版全部在`license`目录 (关注`generateDistLicense`任务的日志警告，补充过时工件的license内容)
+  - 依赖许可证的完整版全部在`licenses`目录 (关注`generateDistLicense`任务的日志警告，补充过时工件的license内容)
   - 如果依赖的是Apache许可证并且存在`NOTICE`文件，那么这些`NOTICE`文件也需要加入到版本的`NOTICE`文件中
 
 ## 发起投票

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
@@ -292,7 +292,7 @@ $ mkdir ${release_version}-${rc_version}
 
 #### 4.1 创建tag
 
-在`${release_version}-release`分支上创建tag，需带有rc版本，为预发布版本
+在`${release_version}-prepare`分支上创建tag，需带有rc版本，为预发布版本
 
 ```shell
 $ git tag -a v{$release_version}-{$rc_version} -m "Tagging the ${release_version} first Release Candidate (Candidates start at zero)"
@@ -554,15 +554,15 @@ Your EventMesh Release Manager
 
 ### 1.合并分支
 
-合并`${release_version}-release`分支的改动到`master`分支，合并完成后删除`release`分支
+合并`${release_version}-prepare`分支的改动到`master`分支，合并完成后删除`release`分支
 
 ```shell
 $ git checkout master
-$ git merge origin/${release_version}-release
+$ git merge origin/${release_version}-prepare
 $ git pull
 $ git push origin master
-$ git push --delete origin ${release_version}-release
-$ git branch -d ${release_version}-release
+$ git push --delete origin ${release_version}-prepare
+$ git branch -d ${release_version}-prepare
 ```
 
 ### 2.迁移源码与二进制包

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/04-release.md
@@ -93,7 +93,7 @@ $ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 579C25F5 # 验证是否
 default-key 28681CB1
 ```
 
-**如果有多个 public key, 也可以删除无用的 key：**
+**如果有多个 public key，也可以删除无用的 key：**
 
 ```shell
 $ gpg --delete-secret-keys 29BBC3CB # 先删除私钥，指明key id
@@ -119,7 +119,7 @@ pub  rsa4096/EE8DAE7D29BBC3CB 2021-04-27 mikexue <mikexue@apache.org>
 Delete this key from the keyring? (y/N) y
 ```
 
-由于公钥服务器没有检查机制，任何人都可以用你的名义上传公钥，所以没有办法保证服务器上的公钥的可靠性。 通常，你可以在网站上公布一个公钥指纹，让其他人核对下载到的公钥是否为真。
+由于公钥服务器没有检查机制，任何人都可以用你的名义上传公钥，所以没有办法保证服务器上的公钥的可靠性。通常，你可以在网站上公布一个公钥指纹，让其他人核对下载到的公钥是否为真。
 
 ```shell
 # fingerprint参数生成公钥指纹：
@@ -130,7 +130,7 @@ uid           [ultimate] mikexue <mikexue@apache.org>
 sub   rsa4096 2021-04-26 [E]
 ```
 
-登录 [https://id.apache.org](https://id.apache.org/), 将上面的 fingerprint （即 F84A 0041 D70B 37AF 9C7B  F0B3 39F4 29D7 579C 25F5） 粘贴到自己的用户信息中 OpenPGP Public Key Primary Fingerprint
+登录 [https://id.apache.org](https://id.apache.org/)，将上面的 fingerprint （即 F84A 0041 D70B 37AF 9C7B  F0B3 39F4 29D7 579C 25F5） 粘贴到自己的用户信息中 OpenPGP Public Key Primary Fingerprint
 
 
 
@@ -163,7 +163,7 @@ version=1.2.0-release
 signing.keyId=579C25F5
 #生成密钥时填的passphrase
 signing.password=
-#导出的私钥文件secring.gpg路径,绝对路径, 比如/home/root/secring.gpg
+#导出的私钥文件secring.gpg的绝对路径,比如/home/root/secring.gpg
 signing.secretKeyRingFile=/home/root/secring.gpg
 #apache 账号
 apacheUserName=
@@ -251,7 +251,7 @@ signing {
 $ gradle signMavenJavaPublication publish
 ```
 
-上述命令执行成功后，待发布版本会自动上传到Apache的临时筹备仓库(staging repository)。所有被deploy到远程[maven仓库](http://repository.apache.org/)的Artifacts都会处于staging状态，访问https://repository.apache.org/#stagingRepositories, 使用Apache的LDAP账户登录后，就会看到上传的版本，`Repository`列的内容即为${STAGING.REPOSITORY}。 点击`Close`来告诉Nexus这个构建已经完成，只有这样该版本才是可用的。 如果电子签名等出现问题，`Close`会失败，可以通过`Activity`查看失败信息。
+上述命令执行成功后，待发布版本会自动上传到Apache的临时筹备仓库(staging repository)。所有被deploy到远程[maven仓库](http://repository.apache.org/)的Artifacts都会处于staging状态，访问https://repository.apache.org/#stagingRepositories，使用Apache的LDAP账户登录后，就会看到上传的版本，`Repository`列的内容即为${STAGING.REPOSITORY}。点击`Close`来告诉Nexus这个构建已经完成，只有这样该版本才是可用的。如果电子签名等出现问题，`Close`会失败，可以通过`Activity`查看失败信息。
 
 
 
@@ -313,7 +313,7 @@ $ tar -czvf apache-eventmesh-${release_version}-source.tar.gz apache-eventmesh-$
 
 > 在`${release_version}-prepare`分支上打包二进制发行版
 
-> 注：`dist`任务所依赖的`generateDistLicense`和`generateDistNotice`任务将会自动生成`tools/dist-license`目录下的`LICENSE`, `NOTICE`文件和`licenses`目录。`dist`任务本身将会复制`tools/dist-license`目录下的内容到`/dist`目录下。
+> 注：`dist`任务所依赖的`generateDistLicense`和`generateDistNotice`任务将会自动生成`tools/dist-license`目录下的`LICENSE`、`NOTICE`文件和`licenses`目录。`dist`任务本身将会复制`tools/dist-license`目录下的内容到`/dist`目录下。
 
 ```shell
 $ ./gradlew clean dist && ./gradlew installPlugin
@@ -445,7 +445,7 @@ $ gpg --verify apache-eventmesh-${release_version}-bin.tar.gz.asc apache-eventme
 
 ### 1.EventMesh社区投票阶段
 
-1. EventMesh社区投票，发起投票邮件到`dev@eventmesh.apache.org`。PMC需要先按照文档检查版本的正确性，然后再进行投票。 经过至少72小时并统计到3个`+1 PMC member`票后，即可进入下一阶段的投票。
+1. EventMesh社区投票，发起投票邮件到`dev@eventmesh.apache.org`。PMC需要先按照文档检查版本的正确性，然后再进行投票。经过至少72小时并统计到3个`+1 PMC member`票后，即可进入下一阶段的投票。
 2. 宣布投票结果,发起投票结果邮件到`dev@eventmesh.apache.org`。
 
 ### 2.EventMesh社区投票模板
@@ -583,7 +583,7 @@ $ svn delete https://dist.apache.org/repos/dist/release/eventmesh/${last_release
 
 ### 4.在Apache Staging仓库发布版本
 
-- 登录http://repository.apache.org , 使用Apache账号登录
+- 登录http://repository.apache.org，使用Apache账号登录
 - 点击左侧的Staging repositories，
 - 搜索EventMesh关键字，选择你最近上传的仓库，投票邮件中指定的仓库
 - 点击上方的`Release`按钮，这个过程会进行一系列检查

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/05-how-to-vote-a-committer-pmc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/05-how-to-vote-a-committer-pmc.md
@@ -1,11 +1,11 @@
 ---
-title: 如何提名新的Committer 和 PMC
+title: 如何提名新的 Committer 和 PMC
 sidebar_position: 4
 ---
-> 介绍Committer 和 PMC成员 的推选要求以及流程。官方指引可参见：https://community.apache.org/newcommitter.html
+> 介绍 Committer 和 PMC 成员 的推选要求以及流程。官方指引可参见：https://community.apache.org/newcommitter.html
 
-## 1.候选人要求
-在投票时，所有 PMC 成员都需要自己决定是否应批准候选人成为提交者。可以通过搜索[邮件列表](https://lists.apache.org/list?dev@eventmesh.apache.org)/[ISSUES/PR](https://github.com/apache/eventmesh/issues)/[官网文档贡献](https://github.com/apache/eventmesh-website)，以了解候选人如何与他人互动，以及他们所做的贡献（代码或文档补丁、建议、参与答疑等）。
+## 1. 候选人要求
+在投票时，所有 PMC 成员都需要自己决定是否应批准候选人成为提交者。可以通过搜索 [邮件列表](https://lists.apache.org/list?dev@eventmesh.apache.org)/[ISSUES/PR](https://github.com/apache/eventmesh/issues)/[官网文档贡献](https://github.com/apache/eventmesh-website)，以了解候选人如何与他人互动，以及他们所做的贡献（代码或文档补丁、建议、参与答疑等）。
 
 以下是在评估候选人的承诺资格时需要考虑的一些要点。
 1. 与社区开发合作的能力？
@@ -29,7 +29,7 @@ sidebar_position: 4
    - 积极回复 ASF 董事会提出的问题，并采取必要的行动
    - 熟悉 ASF 的版本发布流程
 
-在大多数情况下，新的 PMC 成员是从 Committer 团队中提名的。但也可以直接成为 PMC 成员，只要 PMC成员 同意提名，并确信候选人已经准备好。例如，这可以通过他/她曾是 Apache 成员、Apache 官员或另一个项目的 PMC 成员这一事实来证明。
+在大多数情况下，新的 PMC 成员是从 Committer 团队中提名的。但也可以直接成为 PMC 成员，只要 PMC 成员 同意提名，并确信候选人已经准备好。例如，这可以通过他/她曾是 Apache 成员、Apache 官员或另一个项目的 PMC 成员这一事实来证明。
 
 ## 2. 推举详细流程
 
@@ -41,8 +41,7 @@ ${Committer/PMC}：代表推选的类型 Committer/PMC
 
 ### 2.1 发起社区邮件讨论
 
->任何eventmesh的 PMC 成员都可以发起投票讨论，在 PMC 发现社区贡献者任何有价值的贡献并取得候选人本人同意后，可以在eventmesh的private邮件列表发起讨论。讨论邮件里提议者要把候选人的贡献说清楚，并且给出复核对应贡献的地址，便于大家讨论分析。讨论邮件主送private@eventmesh.apache.org邮箱，讨论将持续至少72个小时，项目组成员，包括mentor们会针对提议邮件充分发表自己的看法。
-
+>任何 eventmesh 的 PMC 成员都可以发起投票讨论，在 PMC 发现社区贡献者任何有价值的贡献并取得候选人本人同意后，可以在 eventmesh 的 private 邮件列表发起讨论。讨论邮件里提议者要把候选人的贡献说清楚，并且给出复核对应贡献的地址，便于大家讨论分析。讨论邮件主送 private@eventmesh.apache.org 邮箱，讨论将持续至少 72 个小时，项目组成员，包括 mentor 们会针对提议邮件充分发表自己的看法。
 
 如下是讨论邮件样例：
 
@@ -67,8 +66,7 @@ Thanks!
 
 ### 2.2 发起社区邮件投票
 
->如果讨论邮件在规定时间内没有收到分歧信息，投票发起者需要在eventmesh的private邮件列表发起Committer或 PMC成员 的选举投票。投票邮件主送private@eventmesh.apache.org，至少要3票+1通过；如果存在-1投票则整个投票失败；投票人需要把-1的原因说清楚，便于大家理解和知晓。
-
+>如果讨论邮件在规定时间内没有收到分歧信息，投票发起者需要在 eventmesh 的 private 邮件列表发起 Committer 或 PMC 成员 的选举投票。投票邮件主送 private@eventmesh.apache.org，至少要 3 票 +1 通过；如果存在 -1 投票则整个投票失败；投票人需要把 -1 的原因说清楚，便于大家理解和知晓。
 
 如下是投票邮件样例：
 ```html
@@ -95,7 +93,7 @@ Hi all:
 Thanks!
 ```
 ### 2.3 宣布投票结果
->投票邮件结束后，投票发起者需要在第二封[VOTE]邮件里提醒投票结束；同时，投票发起者需要发起邮票宣布投票结果，发送至private@eventmesh.apache.org。
+>投票邮件结束后，投票发起者需要在第二封 [VOTE] 邮件里提醒投票结束；同时，投票发起者需要发起邮票宣布投票结果，发送至 private@eventmesh.apache.org。
 
 如下投票结果样例：
 ```html
@@ -125,16 +123,17 @@ Thanks!
 
 ### 2.4 新增 PMC 的通知邮件
 
-> 该步骤只针对新的 PMC成员 推举流程，如果选举的是Committer，该步跳过不执行。
-> 投票发起者需要发送至 board@apache.apache.org 邮件组发送知会邮件，并等待至少72小时。
-> 邮件发送 board@apache.org，抄送private@eventmesh.apache.org；PMC成员们会分析合规性，直到没有异议。
+> 该步骤只针对新的 PMC 成员 推举流程，如果选举的是 Committer，该步跳过不执行。
+> 投票发起者需要发送至 board@apache.apache.org 邮件组发送知会邮件，并等待至少 72 小时。
+> 邮件发送 board@apache.org，抄送 private@eventmesh.apache.org；PMC 成员们会分析合规性，直到没有异议。
 
-如下是新增推选 PMC成员 的通知邮件样例：
+如下是新增推选 PMC 成员 的通知邮件样例：
+
 ```html
 To: board@apache.org
 Cc: private@eventmesh.apache.org
 
-Subject：[NOTICE] ${Candidate Name} for EventMesh PMC
+Subject: [NOTICE] ${Candidate Name} for EventMesh PMC
 Content:
 Hi everyone,
 
@@ -148,11 +147,10 @@ Thanks!
 
 72 小时后，如果董事会不反对提名（大多数情况下不会反对），则可以向候选人发送邀请。
 
-
 ### 2.5 向候选人发起邮件邀请
->宣布投票结果邮件发出后，投票发起人要给候选人发送邀请邮件。邀请邮件发送被邀请人，抄送private@eventmesh.apache.org；被邀请的候选人必须通过指定的邮箱地址回复接受或者拒绝该邀请。
+>宣布投票结果邮件发出后，投票发起人要给候选人发送邀请邮件。邀请邮件发送被邀请人，抄送 private@eventmesh.apache.org；被邀请的候选人必须通过指定的邮箱地址回复接受或者拒绝该邀请。
 
-如下是邀请候选人邮件样例：以被邀请人Joe Bloggs为例
+如下是邀请候选人邮件样例：以被邀请人 Joe Bloggs 为例
 
 ```html
 To: JoeBloggs@foo.net
@@ -215,7 +213,7 @@ The Apache EventMesh PMC
 >需要候选人进行处理
 
 新的 Committer 应回复 `private@eventmesh.apache.org`（选择`reply all`），并表达他/她接受邀请。
-然后，该邀请将被项目的 PMC成员 视为已接受。当然，新的 committer 也可以选择拒绝邀请。
+然后，该邀请将被项目的 PMC 成员 视为已接受。当然，新的 committer 也可以选择拒绝邀请。
 
 接受邀请，回复邮件示例
 ```
@@ -234,9 +232,9 @@ XXXX
 一旦邀请被接受，新的提交者需要完成以下事项：
 - 订阅`dev@eventmesh.apache.org`。通常这已经完成了。
 - 选择一个未被使用过 [apache committers list page](http://people.apache.org/committer-index.html) 的 Apache ID。
-- 下载 ICLA 并签署 指引见[ICLA 签署流程](how-to-sign-apache-icla)。
+- 下载 ICLA 并签署 指引见 [ICLA 签署流程](how-to-sign-apache-icla)。
 
-- PMC成员 将等待Apache秘书确认ICLA（或CCLA）备案。新的提交者和 PMC成员 将收到以下电子邮件：
+- PMC 成员 将等待 Apache 秘书确认 ICLA（或 CCLA）备案。新的提交者和 PMC 成员 将收到以下电子邮件：
 
 ```html
 Dear ${Candidate Name},
@@ -250,27 +248,26 @@ Please refer to https://www.apache.org/foundation/how-it-works.html#developers
 for more information about roles at Apache.
 ```
 
-万一该帐户未被处理，PMC 成员应联系项目[Apache Incubator的VP](https://www.apache.org/foundation/), 可以通过 [Apache Account Submission Helper Form](https://whimsy.apache.org/officers/acreq) 请求。
+万一该帐户未被处理，PMC 成员应联系项目 [Apache Incubator 的 VP](https://www.apache.org/foundation/), 可以通过 [Apache Account Submission Helper Form](https://whimsy.apache.org/officers/acreq) 请求。
 
-几天后，新的提交者将收到一封来自root@apache.org帐户通知账号创建的电子邮件，标题为`Welcome to the Apache Software Foundation (ASF)!`。
+几天后，新的提交者将收到一封来自 root@apache.org 帐户通知账号创建的电子邮件，标题为`Welcome to the Apache Software Foundation (ASF)!`。
 
-收到账户创建成功的通知邮件后，可以再次回复之前的邀请邮件，告知EventMesh PMC成员，你的Apache Id账号已经创建，请求将你的Apache Id添加到EventMesh的官方提交者列表中。
-(告知负责提名你的PMC成员通过 [Roster](https://whimsy.apache.org/roster/committee/eventmesh) 页面，将新的提交者添加到官方提交者列表中）
+收到账户创建成功的通知邮件后，可以再次回复之前的邀请邮件，告知 EventMesh PMC 成员，你的 Apache Id 账号已经创建，请求将你的 Apache Id 添加到 EventMesh 的官方提交者列表中。
+（告知负责提名你的 PMC 成员通过 [Roster](https://whimsy.apache.org/roster/committee/eventmesh) 页面，将新的提交者添加到官方提交者列表中）
 
 ### 2.7 设置 Apache ID 和开发环境
 
-- 进入[Apache Account Utility Platform](https://id.apache.org/)，创建密码，设置个人邮箱（`转发邮箱地址`）和GitHub账号（`Your GitHub Username`）。
-- 如果您想使用`xxx@apache.org`邮件服务，请参考[这里](https://infra.apache.org/committer-email.html)。推荐使用 Gmail，因为这种转发模式在大多数邮箱服务设置中都不容易找到。
-- 关注【授权GitHub 2FA wiki】(https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) 开启双因素授权（2FA ) 在 [Github](http://github.com/) 上。当您将 2FA 设置为“关闭”时，它将被相应的 Apache committer 写入权限组除名，直到您再次设置它。 （**注意：像对待密码一样注意恢复代码！**）
-- 使用【GitBox Account Linking Utility】（https://gitbox.apache.org/setup/）获取EventMesh项目的写权限。
-- [eventmesh-website](https://eventmesh.apache.org/team)相关页面更新
+- 进入 [Apache Account Utility Platform](https://id.apache.org/)，创建密码，设置个人邮箱（`转发邮箱地址`）和 GitHub 账号（`Your GitHub Username`）。
+- 如果您想使用`xxx@apache.org`邮件服务，请参考 [这里](https://infra.apache.org/committer-email.html)。推荐使用 Gmail，因为这种转发模式在大多数邮箱服务设置中都不容易找到。
+- 关注【授权 GitHub 2FA wiki】(https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) 开启双因素授权（2FA ) 在 [Github](http://github.com/) 上。当您将 2FA 设置为“关闭”时，它将被相应的 Apache committer 写入权限组除名，直到您再次设置它。 （**注意：像对待密码一样注意恢复代码！**）
+- 使用【GitBox Account Linking Utility】（https://gitbox.apache.org/setup/）获取 EventMesh 项目的写权限。
+- [eventmesh-website](https://eventmesh.apache.org/team) 相关页面更新
 
 如果您想在 Apache GitHub 组织中公开露面，您需要前往 [Apache GitHub 人员页面](https://github.com/orgs/apache/people)，
 搜索自己，然后选择`Organization visibility`为`Public`。
 
-
 ## 3 发布公告邮件
->如上步骤都完成后，投票发起人向dev@eventmesh.apache.org邮件组发通知邮件。
+>如上步骤都完成后，投票发起人向 dev@eventmesh.apache.org 邮件组发通知邮件。
 
 如下是通知邮件样例：
 ```html
@@ -290,13 +287,13 @@ Thanks!
 The Apache EventMesh PMC
 ```
 
-到此，整个流程才算走完，候选人才正式的成为项目的Committer或者PMC成员。
+到此，整个流程才算走完，候选人才正式的成为项目的 Committer 或者 PMC 成员。
 
 ## 4 操作流程总结
-1. 发送携带ICLA附件的邮件
-2. 1-2天后收到回复邮件，将在5个工作日内处理
-3. 2-5天内收到apache账户创建成功邮件
+1. 发送携带 ICLA 附件的邮件
+2. 1-2 天后收到回复邮件，将在 5 个工作日内处理
+3. 2-5 天内收到 apache 账户创建成功邮件
 4. 使用邮件提示内容找回密码或重置密码
-5. 登录id.apache.org或whimsy.apache.org关联github账号
-6. 开启Github的2FA认证（双因子认证）
-7. 使用gitbox.apache.org获得仓库写入权限  
+5. 登录 id.apache.org 或 whimsy.apache.org 关联 github 账号
+6. 开启 Github 的 2FA 认证（双因子认证）
+7. 使用 gitbox.apache.org 获得仓库写入权限  

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -280,7 +280,7 @@ const Download = (): JSX.Element => (
             with the OpenPGP signature.
             The signature should be matched against the
             {' '}
-            <a href="https://downloads.apache.org/incubator/eventmesh/KEYS">KEYS</a>
+            <a href="https://downloads.apache.org/eventmesh/KEYS">KEYS</a>
             {' '}
             file which contains
             the OpenPGP keys of EventMesh&apos;s Release Managers.


### PR DESCRIPTION
Fixes #217

- Add Document changes in https://github.com/apache/eventmesh/pull/4831 and https://github.com/apache/eventmesh/pull/4827.
- Update outdated branch name and url
- Add PR template