### PR TITLE
[ISSUE #159] [Doc] The introductions of EventMesh Connector and EventMesh Storage are incorrect

### DIFF
--- a/docs/instruction/03-runtime.md
+++ b/docs/instruction/03-runtime.md
@@ -271,3 +271,5 @@ When the following logs are printed to the console, EventMesh Runtime has stoppe
 DEBUG StatusConsoleListener Shutdown hook enabled. Registering a new one.
 WARN StatusConsoleListener Unable to register Log4j shutdown hook because JVM is shutting down. Using SimpleLogger
 ```
+
+**Note on Connectors:** EventMesh Connectors, such as the eventmesh-connector-rocketmq, can be deployed on any machine and are used to integrate with different data sources and sinks. They are separate from the EventMesh Runtime but can be configured to work alongside it.

--- a/docs/instruction/03-runtime.md
+++ b/docs/instruction/03-runtime.md
@@ -1,6 +1,6 @@
 # EventMesh Runtime Quick Start
 
-EventMesh Runtime is a stateful Mesh node in the EventMesh cluster, responsible for event transmission between Source Connectors and Sink Connectors. It uses Event Store as a storage queue for events.
+EventMesh Runtime is a stateful Mesh node in the EventMesh cluster, responsible for event transmission between Source Connectors and Sink Connectors. It uses EventMesh Storage as a storage queue for events.
 
 ![EventMesh Runtime](../../static/images/design-document/runtime.png)
 
@@ -23,7 +23,7 @@ cd apache-eventmesh-1.10.0
 
 ### 1.3 Configuration
 
-This document provides an example of deploying it with RocketMQ as Event Store, but you can also choose another [Event Store supported by EventMesh](../roadmap.md#event-store-implementation-status). If you choose a non-standalone mode, ensure that [RocketMQ is successfully started](https://rocketmq.apache.org/docs/quick-start/) and accessible via IP address. If you stick to the default standalone mode, RocketMQ doesn't need to be started.
+This document provides an example of deploying it with RocketMQ as EventMesh Storage, but you can also choose another [EventMesh Storage supported by EventMesh](../roadmap.md#event-store-implementation-status). If you choose a non-standalone mode, ensure that [RocketMQ is successfully started](https://rocketmq.apache.org/docs/quick-start/) and accessible via IP address. If you stick to the default standalone mode, RocketMQ doesn't need to be started.
 
 #### 1.3.1 EventMesh Runtime Configuration
 
@@ -33,7 +33,7 @@ This configuration file includes settings for the EventMesh Runtime environment 
 vim conf/eventmesh.properties
 ```
 
-Specify RocketMQ as Event Store:
+Specify RocketMQ as EventMesh Storage:
 
 ```properties
 # storage plugin
@@ -49,7 +49,7 @@ Check if the default ports in the configuration file are occupied. If occupied, 
 | eventMesh.server.grpc.port          | 10205   | gRPC listening port |
 | eventMesh.server.admin.http.port    | 10106   | HTTP management port |
 
-#### 1.3.2 Event Store Configuration
+#### 1.3.2 EventMesh Storage Configuration
 
 In the case of RocketMQ, the configuration file includes parameters required to connect to the RocketMQ namesrv.
 
@@ -203,7 +203,7 @@ cd apache-eventmesh-1.10.0-src/
 | eventmesh-starter        | Entry point for running EventMesh locally                    |
 | eventmesh-runtime        | EventMesh Runtime, the runtime module                        |
 | eventmesh-connectors     | [Connectors](../design-document/03-connect/00-connectors.md) for connecting event sources and sinks, supporting [various services and platforms](../roadmap.md#connector-implementation-status) |
-| eventmesh-storage-plugin | [Event Store](../roadmap.md#event-store-implementation-status) plugin for EventMesh Runtime |
+| eventmesh-storage-plugin | [EventMesh Storage](../roadmap.md#event-store-implementation-status) plugin for EventMesh Runtime |
 | eventmesh-sdks           | Multi-language client SDKs for EventMesh, including Java, Go, C and Rust |
 | eventmesh-examples       | Examples of SDK usage                                        |
 | eventmesh-spi            | Module for loading EventMesh SPI                             |
@@ -241,7 +241,7 @@ dependencies {
 
 #### 3.4.2 Use Plugins
 
-EventMesh will load the plugins by default from the `dist/plugin` directory. You can change the plugin directory using `-DeventMeshPluginDir=your_plugin_directory`. The plugin instances needed at runtime can be configured in the `confPath` directory in the `eventmesh.properties` file. For example, by setting the following, you declare the use of the RocketMQ as Event Store:
+EventMesh will load the plugins by default from the `dist/plugin` directory. You can change the plugin directory using `-DeventMeshPluginDir=your_plugin_directory`. The plugin instances needed at runtime can be configured in the `confPath` directory in the `eventmesh.properties` file. For example, by setting the following, you declare the use of the RocketMQ as EventMesh Storage:
 
 ```properties
 # storage plugin


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #159 

### Motivation

*Explain the content here.*

The content of the EventMesh Runtime documentation was outdated and contained incorrect references to the EventMesh Connector. The documentation needed updates to ensure accurate instructions for configuring EventMesh Storage, as well as correcting/checking image paths and terminology.

*Explain why you want to make the changes and what problem you're trying to solve.*

The changes were made to address user confusion regarding the correct setup and usage of EventMesh Storage and Connectors, as highlighted in issues #159 and #4680. This ensures users can correctly configure and deploy EventMesh with RocketMQ as the storage layer.

### Modifications

*Describe the modifications you've done.*

* Updated all references from "EventMesh Connector" to "EventMesh Storage" where applicable.

* Checked the image path to make sure it started with /static/images/ so images are correctly displayed.

* Revised configuration instructions to specify eventMesh.storage.plugin.type=rocketmq instead of eventMesh.connector.plugin.type.

* Added a note at the bottom to clarify the distinction between EventMesh Connectors and EventMesh Storage, including their deployment and configuration.

Do let me know if there's anything that needs fixing or if I understood the instructions wrong. Thanks!

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
- If a feature is not applicable for documentation, explain why? not applicable
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation. not applicable 