### PR TITLE
docs: fix SPI storage plugin example

### DIFF
--- a/docs/design-document/01-spi.md
+++ b/docs/design-document/01-spi.md
@@ -81,7 +81,7 @@ In the future, we might support the implementation to load from the maven reposi
 
 The following is an example of how to use the SPI to declare a plugin.
 
-First, we create an eventmesh-connector-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
+First, we create an eventmesh-storage-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
 which indicates the MeshMQProducer is an SPI interface.
 
 ```java
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-Then we create an eventmesh-connector-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
+Then we create an eventmesh-storage-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -100,14 +100,14 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 ```
 
 At the same time, we need to create a file with the full qualified name of the SPI interface under the resource/META-INF/eventmesh directory
-in the eventmesh-connector-rocketmq module.
+in the eventmesh-storage-rocketmq module.
 
 org.apache.eventmesh.api.producer.Producer
 
 The content of the file is the extension instance name and the corresponding instance full class name
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 At this point, an SPI expansion module is complete. We can use `EventMeshExtensionFactory.getExtension(MeshMQProducer.class, "rocketmq")` to get the `RocketMQProducerImpl` instance.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/design-document/01-spi.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/design-document/01-spi.md
@@ -80,9 +80,9 @@ MetaInfExtensionClassLoader 用于从 classPath 直接加载实现类，JarExten
 
 ## SPI 使用示例
 
-下面以 eventmesh-connector-plugin 为例，介绍 SPI 具体的使用过程。
+下面以 eventmesh-storage-plugin 为例，介绍 SPI 具体的使用过程。
 
-首先定义一个 eventmesh-connector-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
+首先定义一个 eventmesh-storage-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
 
 ```java
 @EventMeshSPI(isSingleton = false)
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-eventmesh-connector-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
+eventmesh-storage-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -99,13 +99,13 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 }
 ```
 
-同时，还需要在 eventmesh-connector-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
+同时，还需要在 eventmesh-storage-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
 org.apache.eventmesh.api.producer.Producer
 
 文件内容为扩展实例名和对应的实例全类名
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 至此，一个 SPI 扩展模块就完成了。在使用的时候只需要通过 EventMeshExtensionFactory.getExtension(MeshMQProducer.class, “rocketmq”) 就可以获取 RocketMQProducerImpl 实现类。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.10.0/design-document/01-spi.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.10.0/design-document/01-spi.md
@@ -80,9 +80,9 @@ MetaInfExtensionClassLoader 用于从 classPath 直接加载实现类，JarExten
 
 ## SPI 使用示例
 
-下面以 eventmesh-connector-plugin 为例，介绍 SPI 具体的使用过程。
+下面以 eventmesh-storage-plugin 为例，介绍 SPI 具体的使用过程。
 
-首先定义一个 eventmesh-connector-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
+首先定义一个 eventmesh-storage-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
 
 ```java
 @EventMeshSPI(isSingleton = false)
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-eventmesh-connector-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
+eventmesh-storage-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -99,13 +99,13 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 }
 ```
 
-同时，还需要在 eventmesh-connector-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
+同时，还需要在 eventmesh-storage-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
 org.apache.eventmesh.api.producer.Producer
 
 文件内容为扩展实例名和对应的实例全类名
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 至此，一个 SPI 扩展模块就完成了。在使用的时候只需要通过 EventMeshExtensionFactory.getExtension(MeshMQProducer.class, “rocketmq”) 就可以获取 RocketMQProducerImpl 实现类。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.11.0/design-document/01-spi.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.11.0/design-document/01-spi.md
@@ -80,9 +80,9 @@ MetaInfExtensionClassLoader 用于从 classPath 直接加载实现类，JarExten
 
 ## SPI 使用示例
 
-下面以 eventmesh-connector-plugin 为例，介绍 SPI 具体的使用过程。
+下面以 eventmesh-storage-plugin 为例，介绍 SPI 具体的使用过程。
 
-首先定义一个 eventmesh-connector-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
+首先定义一个 eventmesh-storage-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
 
 ```java
 @EventMeshSPI(isSingleton = false)
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-eventmesh-connector-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
+eventmesh-storage-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -99,13 +99,13 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 }
 ```
 
-同时，还需要在 eventmesh-connector-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
+同时，还需要在 eventmesh-storage-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
 org.apache.eventmesh.api.producer.Producer
 
 文件内容为扩展实例名和对应的实例全类名
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 至此，一个 SPI 扩展模块就完成了。在使用的时候只需要通过 EventMeshExtensionFactory.getExtension(MeshMQProducer.class, “rocketmq”) 就可以获取 RocketMQProducerImpl 实现类。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.12.0/design-document/01-spi.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.12.0/design-document/01-spi.md
@@ -80,9 +80,9 @@ MetaInfExtensionClassLoader 用于从 classPath 直接加载实现类，JarExten
 
 ## SPI 使用示例
 
-下面以 eventmesh-connector-plugin 为例，介绍 SPI 具体的使用过程。
+下面以 eventmesh-storage-plugin 为例，介绍 SPI 具体的使用过程。
 
-首先定义一个 eventmesh-connector-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
+首先定义一个 eventmesh-storage-api 模块，并且定义扩展接口 MeshMQProducer。在 MeshMQProducer 接口上使用@EventMeshSPI 注解进行声明，表明该接口是一个 SPI 扩展接口
 
 ```java
 @EventMeshSPI(isSingleton = false)
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-eventmesh-connector-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
+eventmesh-storage-rocketmq 模块中包含采用 rocketmq 的具体实现方式 RocketMQProducerImpl。
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -99,13 +99,13 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 }
 ```
 
-同时，还需要在 eventmesh-connector-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
+同时，还需要在 eventmesh-storage-rocketmq 模块中 resource/META-INF/eventmesh 目录下创建文件名为 SPI 接口全限定名的文件
 org.apache.eventmesh.api.producer.Producer
 
 文件内容为扩展实例名和对应的实例全类名
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 至此，一个 SPI 扩展模块就完成了。在使用的时候只需要通过 EventMeshExtensionFactory.getExtension(MeshMQProducer.class, “rocketmq”) 就可以获取 RocketMQProducerImpl 实现类。

--- a/versioned_docs/version-v1.10.0/design-document/01-spi.md
+++ b/versioned_docs/version-v1.10.0/design-document/01-spi.md
@@ -81,7 +81,7 @@ In the future, we might support the implementation to load from the maven reposi
 
 The following is an example of how to use the SPI to declare a plugin.
 
-First, we create an eventmesh-connector-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
+First, we create an eventmesh-storage-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
 which indicates the MeshMQProducer is an SPI interface.
 
 ```java
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-Then we create an eventmesh-connector-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
+Then we create an eventmesh-storage-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -100,14 +100,14 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 ```
 
 At the same time, we need to create a file with the full qualified name of the SPI interface under the resource/META-INF/eventmesh directory
-in the eventmesh-connector-rocketmq module.
+in the eventmesh-storage-rocketmq module.
 
 org.apache.eventmesh.api.producer.Producer
 
 The content of the file is the extension instance name and the corresponding instance full class name
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 At this point, an SPI expansion module is complete. We can use `EventMeshExtensionFactory.getExtension(MeshMQProducer.class, "rocketmq")` to get the `RocketMQProducerImpl` instance.

--- a/versioned_docs/version-v1.11.0/design-document/01-spi.md
+++ b/versioned_docs/version-v1.11.0/design-document/01-spi.md
@@ -81,7 +81,7 @@ In the future, we might support the implementation to load from the maven reposi
 
 The following is an example of how to use the SPI to declare a plugin.
 
-First, we create an eventmesh-connector-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
+First, we create an eventmesh-storage-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
 which indicates the MeshMQProducer is an SPI interface.
 
 ```java
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-Then we create an eventmesh-connector-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
+Then we create an eventmesh-storage-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -100,14 +100,14 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 ```
 
 At the same time, we need to create a file with the full qualified name of the SPI interface under the resource/META-INF/eventmesh directory
-in the eventmesh-connector-rocketmq module.
+in the eventmesh-storage-rocketmq module.
 
 org.apache.eventmesh.api.producer.Producer
 
 The content of the file is the extension instance name and the corresponding instance full class name
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 At this point, an SPI expansion module is complete. We can use `EventMeshExtensionFactory.getExtension(MeshMQProducer.class, "rocketmq")` to get the `RocketMQProducerImpl` instance.

--- a/versioned_docs/version-v1.12.0/design-document/01-spi.md
+++ b/versioned_docs/version-v1.12.0/design-document/01-spi.md
@@ -81,7 +81,7 @@ In the future, we might support the implementation to load from the maven reposi
 
 The following is an example of how to use the SPI to declare a plugin.
 
-First, we create an eventmesh-connector-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
+First, we create an eventmesh-storage-api module, and define the extension interface MeshMQProducer, and we use @EventMeshSPI on the MeshMQProducer,
 which indicates the MeshMQProducer is an SPI interface.
 
 ```java
@@ -91,7 +91,7 @@ public interface MeshMQProducer extends Producer {
 }
 ```
 
-Then we create an eventmesh-connector-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
+Then we create an eventmesh-storage-rocketmq module, which contains the concrete implementation named RocketMQProducerImpl.
 
 ```java
 public class RocketMQProducerImpl implements MeshMQProducer {
@@ -100,14 +100,14 @@ public class RocketMQProducerImpl implements MeshMQProducer {
 ```
 
 At the same time, we need to create a file with the full qualified name of the SPI interface under the resource/META-INF/eventmesh directory
-in the eventmesh-connector-rocketmq module.
+in the eventmesh-storage-rocketmq module.
 
 org.apache.eventmesh.api.producer.Producer
 
 The content of the file is the extension instance name and the corresponding instance full class name
 
 ```properties
-rocketmq=org.apache.eventmesh.connector.rocketmq.producer.RocketMQProducerImpl
+rocketmq=org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl
 ```
 
 At this point, an SPI expansion module is complete. We can use `EventMeshExtensionFactory.getExtension(MeshMQProducer.class, "rocketmq")` to get the `RocketMQProducerImpl` instance.


### PR DESCRIPTION
## Summary
- update the SPI plugin example to refer to `eventmesh-storage-api` and `eventmesh-storage-rocketmq`
- update the RocketMQ producer implementation package from `org.apache.eventmesh.connector...` to `org.apache.eventmesh.storage...`
- apply the same docs fix to current docs and v1.10/v1.11/v1.12 English + Chinese pages

## Test plan
- `git diff --check`
- `rg "eventmesh-connector-(plugin|api|rocketmq)|org\\.apache\\.eventmesh\\.connector\\.rocketmq"` on the updated files returns no matches
- verified current EventMesh source paths with GitHub code search

Fixes #171